### PR TITLE
fix: add displayName to all components for React DevTools readability

### DIFF
--- a/src/components/Badge.tsx
+++ b/src/components/Badge.tsx
@@ -113,4 +113,6 @@ const Badge: React.FC<BadgeProps> = ({
   );
 };
 
+Badge.displayName = "CyberUI.Badge";
+
 export default Badge;

--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -131,4 +131,6 @@ const Button: React.FC<ButtonProps> = ({
   );
 };
 
+Button.displayName = "CyberUI.Button";
+
 export default Button;

--- a/src/components/Card.tsx
+++ b/src/components/Card.tsx
@@ -97,4 +97,6 @@ const Card: React.FC<CardProps> = ({
   );
 };
 
+Card.displayName = "CyberUI.Card";
+
 export default Card;

--- a/src/components/Carousel.tsx
+++ b/src/components/Carousel.tsx
@@ -891,4 +891,6 @@ const Carousel: React.FC<CarouselProps> = ({
   );
 };
 
+Carousel.displayName = "CyberUI.Carousel";
+
 export default memo(Carousel);

--- a/src/components/Checkbox.tsx
+++ b/src/components/Checkbox.tsx
@@ -162,5 +162,7 @@ const Checkbox: React.FC<CheckboxProps> = ({
   );
 };
 
+Checkbox.displayName = "CyberUI.Checkbox";
+
 export default Checkbox;
 

--- a/src/components/CircularProgress.tsx
+++ b/src/components/CircularProgress.tsx
@@ -127,4 +127,6 @@ const CircularProgress: React.FC<CircularProgressProps> = ({
   );
 };
 
+CircularProgress.displayName = "CyberUI.CircularProgress";
+
 export default CircularProgress;

--- a/src/components/Divider.tsx
+++ b/src/components/Divider.tsx
@@ -71,4 +71,6 @@ const Divider: React.FC<DividerProps> = ({
   return <div className={dividerClasses} />;
 };
 
+Divider.displayName = "CyberUI.Divider";
+
 export default Divider;

--- a/src/components/GradientText.tsx
+++ b/src/components/GradientText.tsx
@@ -72,4 +72,6 @@ const GradientText: React.FC<GradientTextProps> = ({
   );
 };
 
+GradientText.displayName = "CyberUI.GradientText";
+
 export default GradientText;

--- a/src/components/Input.tsx
+++ b/src/components/Input.tsx
@@ -188,4 +188,6 @@ const Input: React.FC<InputProps> = ({
   );
 };
 
+Input.displayName = "CyberUI.Input";
+
 export default Input;

--- a/src/components/LinearProgress.tsx
+++ b/src/components/LinearProgress.tsx
@@ -84,4 +84,6 @@ const LinearProgress: React.FC<LinearProgressProps> = ({
   );
 };
 
+LinearProgress.displayName = "CyberUI.LinearProgress";
+
 export default LinearProgress;

--- a/src/components/Notification.tsx
+++ b/src/components/Notification.tsx
@@ -151,4 +151,6 @@ const Notification: React.FC<NotificationProps> = ({
   );
 };
 
+Notification.displayName = "CyberUI.Notification";
+
 export default Notification;

--- a/src/components/SectionTitle.tsx
+++ b/src/components/SectionTitle.tsx
@@ -85,5 +85,7 @@ const SectionTitle: React.FC<SectionTitleProps> = ({
   );
 };
 
+SectionTitle.displayName = "CyberUI.SectionTitle";
+
 export default SectionTitle;
 

--- a/src/components/SegmentedProgress.tsx
+++ b/src/components/SegmentedProgress.tsx
@@ -187,4 +187,6 @@ const SegmentedProgress: React.FC<SegmentedProgressProps> = (props) => {
   return <RadialProgress {...props} />;
 };
 
+SegmentedProgress.displayName = "CyberUI.SegmentedProgress";
+
 export default SegmentedProgress;

--- a/src/components/Select.tsx
+++ b/src/components/Select.tsx
@@ -209,4 +209,6 @@ const Select: React.FC<SelectProps> = ({
   );
 };
 
+Select.displayName = "CyberUI.Select";
+
 export default Select;

--- a/src/components/Skeleton.tsx
+++ b/src/components/Skeleton.tsx
@@ -220,4 +220,6 @@ const Skeleton: React.FC<SkeletonProps> = ({
   );
 };
 
+Skeleton.displayName = "CyberUI.Skeleton";
+
 export default Skeleton;

--- a/src/components/Steps.tsx
+++ b/src/components/Steps.tsx
@@ -233,5 +233,7 @@ const Steps: React.FC<StepsProps> = ({
   );
 };
 
+Steps.displayName = "CyberUI.Steps";
+
 export default Steps;
 

--- a/src/components/TabNavigation.tsx
+++ b/src/components/TabNavigation.tsx
@@ -337,4 +337,6 @@ const TabNavigation: React.FC<TabNavigationProps> = ({
   );
 };
 
+TabNavigation.displayName = "CyberUI.TabNavigation";
+
 export default TabNavigation;

--- a/src/components/Timeline.tsx
+++ b/src/components/Timeline.tsx
@@ -199,5 +199,7 @@ const Timeline: React.FC<TimelineProps> = ({
   );
 };
 
+Timeline.displayName = "CyberUI.Timeline";
+
 export default Timeline;
 

--- a/src/components/Toggle.tsx
+++ b/src/components/Toggle.tsx
@@ -138,4 +138,6 @@ const Toggle: React.FC<ToggleProps> = ({
   );
 };
 
+Toggle.displayName = "CyberUI.Toggle";
+
 export default Toggle;


### PR DESCRIPTION
## What

Added `ComponentName.displayName = "CyberUI.ComponentName"` to all 19 components that were still missing it. Only `Modal` and `Image` had it set previously.

## Why

Without displayName, React DevTools shows all CyberUI components as anonymous — makes debugging a guessing game. Now every component shows up with a clean `CyberUI.Whatever` label.

## Changes

- **19 components**: `Badge`, `Button`, `Card`, `Carousel`, `Checkbox`, `CircularProgress`, `Divider`, `GradientText`, `Input`, `LinearProgress`, `Notification`, `SectionTitle`, `SegmentedProgress`, `Select`, `Skeleton`, `Steps`, `TabNavigation`, `Timeline`, `Toggle`
- Each got one line: `ComponentName.displayName = "CyberUI.ComponentName"`
- 0 logic changes, 0 imports, just the displayName assignment before `export default`

Closes #1