### PR TITLE
feat: add Tooltip component

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -38,6 +38,7 @@ import "cyberui-2045/styles.css";
 | `Notification` | Toast notifications. Use `useCyberNotifications` hook. |
 | `Badge` | Status indicator. Variants: `primary`, `secondary`, `accent`, `success`, `error`, `warning`. |
 | `Skeleton` | Loading placeholder. |
+| `Tooltip` | Neon-bordered popover on hover/focus. Placements: `top`, `bottom`, `left`, `right`. |
 | `CircularProgress` | Dual-ring circular progress indicator. |
 | `SegmentedProgress` | Segmented progress: `variant="radial"` (circular arc gauge, default) or `variant="block"` (discrete filled blocks ▮▮▮▯▯). |
 | `LinearProgress` | Smooth horizontal progress bar. |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **`Tooltip`** component — a neon-bordered popover that reveals supplemental info on hover or keyboard focus. Supports `placement` (`top`/`bottom`/`left`/`right`, responsive), `variant` (`primary`/`secondary`/`accent`, reusing Button/Card's palette), `size`, a configurable show `delay`, `disabled`, and controlled (`open`/`onOpenChange`) or uncontrolled usage. Wires `aria-describedby` onto the trigger and dismisses on Escape.
+
 ## [2.4.0] - 2026-07-10
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,7 +32,7 @@ npm test              # All tests (unit + Storybook/Playwright)
 |-------------|-----------|
 | Forms | Button, Input, Toggle, Select, Checkbox |
 | Layout | Card, Modal, Divider |
-| Feedback | Notification, Badge, Skeleton |
+| Feedback | Notification, Badge, Skeleton, Tooltip |
 | Progress | CircularProgress, SegmentedProgress, LinearProgress |
 | Navigation | TabNavigation, Carousel, Steps |
 | Typography | GradientText, SectionTitle |

--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ function App() {
 | Notification | Feedback | [→](https://patrickkuei.github.io/CyberUI/storybook/?path=/docs/components-notification--docs) |
 | Badge | Feedback | [→](https://patrickkuei.github.io/CyberUI/storybook/?path=/docs/components-badge--docs) |
 | Skeleton | Feedback | [→](https://patrickkuei.github.io/CyberUI/storybook/?path=/docs/components-skeleton--docs) |
+| Tooltip | Feedback | [→](https://patrickkuei.github.io/CyberUI/storybook/?path=/docs/components-tooltip--docs) |
 | CircularProgress | Progress | [→](https://patrickkuei.github.io/CyberUI/storybook/?path=/docs/components-circularprogress--docs) |
 | SegmentedProgress | Progress | [→](https://patrickkuei.github.io/CyberUI/storybook/?path=/docs/components-segmentedprogress--docs) |
 | LinearProgress | Progress | [→](https://patrickkuei.github.io/CyberUI/storybook/?path=/docs/components-linearprogress--docs) |

--- a/bin/usage-content.js
+++ b/bin/usage-content.js
@@ -42,6 +42,7 @@ Paths below are relative to \`node_modules/cyberui-2045/\`.
 | Notification | Feedback | \`dist/components/Notification.d.ts\` |
 | Badge | Feedback | \`dist/components/Badge.d.ts\` |
 | Skeleton | Feedback | \`dist/components/Skeleton.d.ts\` |
+| Tooltip | Feedback | \`dist/components/Tooltip.d.ts\` |
 | CircularProgress | Progress | \`dist/components/CircularProgress.d.ts\` |
 | SegmentedProgress | Progress | \`dist/components/SegmentedProgress.d.ts\` |
 | LinearProgress | Progress | \`dist/components/LinearProgress.d.ts\` |

--- a/public/component-manifest.json
+++ b/public/component-manifest.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 1,
-  "packageVersion": "2.3.1",
-  "generatedAt": "2026-07-10T05:23:33.463Z",
+  "packageVersion": "2.4.0",
+  "generatedAt": "2026-07-10T06:59:23.331Z",
   "categoryOrder": [
     "Forms",
     "Layout",
@@ -702,6 +702,95 @@
           "required": false,
           "default": true,
           "description": "Whether to show the pulse animation."
+        }
+      ]
+    },
+    {
+      "name": "Tooltip",
+      "category": "Feedback",
+      "sourceFile": "src/components/Tooltip.tsx",
+      "displayName": "Tooltip",
+      "description": "A neon-bordered popover that reveals supplemental info on hover or keyboard focus.",
+      "docSummary": "Neon-bordered popover on hover/focus. Placements: `top`, `bottom`, `left`, `right`.",
+      "storybookPath": "components-tooltip--docs",
+      "manifestOverride": false,
+      "props": [
+        {
+          "name": "children",
+          "type": "ReactElement<{ 'aria-describedby'?: string | undefined; }, string | JSXElementConstructor<any>>",
+          "required": true,
+          "default": null,
+          "description": "The trigger element. Must be a single React element that accepts an\n`aria-describedby` attribute (native elements, `Button`, `Badge`, etc).\nWrap plain text/icons in a `<span tabIndex={0}>` so the trigger is\nkeyboard-focusable — the tooltip only opens on hover or focus."
+        },
+        {
+          "name": "content",
+          "type": "ReactNode",
+          "required": true,
+          "default": null,
+          "description": "Content rendered inside the tooltip panel."
+        },
+        {
+          "name": "placement",
+          "type": "ResponsiveValue<TooltipPlacement> | undefined",
+          "required": false,
+          "default": "top",
+          "description": "Side of the trigger the tooltip is anchored to. Supports responsive values."
+        },
+        {
+          "name": "variant",
+          "type": "\"primary\" | \"secondary\" | \"accent\" | undefined",
+          "required": false,
+          "default": "primary",
+          "description": "Visual style, reusing the neon palette from Button/Card."
+        },
+        {
+          "name": "size",
+          "type": "ResponsiveValue<\"sm\" | \"md\" | \"lg\"> | undefined",
+          "required": false,
+          "default": "md",
+          "description": "Size of the tooltip panel (text size + padding). Supports responsive values."
+        },
+        {
+          "name": "delay",
+          "type": "number | undefined",
+          "required": false,
+          "default": 200,
+          "description": "Delay in ms before the tooltip appears after hover/focus starts.\nHiding is always immediate so the panel doesn't linger."
+        },
+        {
+          "name": "disabled",
+          "type": "boolean | undefined",
+          "required": false,
+          "default": false,
+          "description": "Disables the tooltip — the trigger renders as-is with no hover/focus behavior."
+        },
+        {
+          "name": "open",
+          "type": "boolean | undefined",
+          "required": false,
+          "default": null,
+          "description": "Controlled visibility. When set, the tooltip stops managing its own open\nstate and `onOpenChange` becomes the only way to react to hover/focus/Escape."
+        },
+        {
+          "name": "onOpenChange",
+          "type": "((open: boolean) => void) | undefined",
+          "required": false,
+          "default": null,
+          "description": "Fired whenever hover, focus, blur, or Escape would change visibility."
+        },
+        {
+          "name": "className",
+          "type": "string | undefined",
+          "required": false,
+          "default": "",
+          "description": "Additional CSS classes for the tooltip panel."
+        },
+        {
+          "name": "id",
+          "type": "string | undefined",
+          "required": false,
+          "default": null,
+          "description": "Id for the tooltip panel. Auto-generated when omitted."
         }
       ]
     },

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -16,10 +16,10 @@ npm install cyberui-2045
 ```
 
 <!-- cyberui-2045:manifest:start -->
-## Components (21)
+## Components (22)
 - Forms: `Button`, `Input`, `Toggle`, `Select`, `Checkbox`
 - Layout: `Card`, `Modal`, `Divider`
-- Feedback: `Notification`, `Badge`, `Skeleton`
+- Feedback: `Notification`, `Badge`, `Skeleton`, `Tooltip`
 - Progress: `CircularProgress`, `SegmentedProgress`, `LinearProgress`
 - Navigation: `TabNavigation`, `Carousel`, `Steps`
 - Typography: `GradientText`, `SectionTitle`

--- a/scripts/generate-manifest.js
+++ b/scripts/generate-manifest.js
@@ -23,7 +23,7 @@ const CATEGORY_ORDER = ['Forms', 'Layout', 'Feedback', 'Progress', 'Navigation',
 const CATEGORY_MAP = {
   Button: 'Forms', Input: 'Forms', Select: 'Forms', Toggle: 'Forms', Checkbox: 'Forms',
   Card: 'Layout', Modal: 'Layout', Divider: 'Layout',
-  Notification: 'Feedback', Badge: 'Feedback', Skeleton: 'Feedback',
+  Notification: 'Feedback', Badge: 'Feedback', Skeleton: 'Feedback', Tooltip: 'Feedback',
   CircularProgress: 'Progress', LinearProgress: 'Progress', SegmentedProgress: 'Progress',
   TabNavigation: 'Navigation', Carousel: 'Navigation', Steps: 'Navigation',
   GradientText: 'Typography', SectionTitle: 'Typography',
@@ -57,6 +57,7 @@ const DOC_SUMMARIES = {
   SectionTitle: 'Title with decorative gradient line.',
   Steps: 'Multi-step progress indicator.',
   Timeline: 'Vertical event history display.',
+  Tooltip: 'Neon-bordered popover on hover/focus. Placements: `top`, `bottom`, `left`, `right`.',
 };
 
 // SegmentedProgress exports `type SegmentedProgressProps = RadialProps | BlockProps`,

--- a/src/components/Tooltip.stories.tsx
+++ b/src/components/Tooltip.stories.tsx
@@ -1,0 +1,282 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import Tooltip from './Tooltip';
+import Button from './Button';
+import Badge from './Badge';
+
+const meta: Meta<typeof Tooltip> = {
+  title: 'Components/Tooltip',
+  component: Tooltip,
+  parameters: {
+    layout: 'centered',
+    docs: {
+      description: {
+        component: `A neon-bordered popover that reveals supplemental info on hover or keyboard focus.
+
+**Usage:**
+
+\`\`\`tsx
+import React from 'react';
+import { Tooltip, Button, Badge } from 'cyberui-2045';
+import 'cyberui-2045/styles.css';
+
+// Basic usage
+<Tooltip content="Initiates a full system diagnostic scan.">
+  <Button variant="primary">Run Diagnostics</Button>
+</Tooltip>
+
+// Placement
+<Tooltip content="Cannot be undone." placement="right">
+  <Badge variant="error">DANGER</Badge>
+</Tooltip>
+
+// Variant
+<Tooltip content="Neural link established." variant="accent">
+  <Badge variant="success">ONLINE</Badge>
+</Tooltip>
+
+// Controlled
+const [open, setOpen] = React.useState(false);
+<Tooltip content="Manually controlled." open={open} onOpenChange={setOpen}>
+  <Button>Toggle</Button>
+</Tooltip>
+
+// Disabled
+<Tooltip content="Never shows." disabled>
+  <Button>No Tooltip</Button>
+</Tooltip>
+\`\`\`
+
+**Props:**
+
+| Prop | Type | Required | Default | Description |
+|------|------|----------|---------|-------------|
+| \`children\` | \`React.ReactElement\` | ✅ | - | Trigger element (must accept \`aria-describedby\`) |
+| \`content\` | \`React.ReactNode\` | ✅ | - | Tooltip panel content |
+| \`placement\` | \`'top' \\| 'bottom' \\| 'left' \\| 'right' \\| ResponsiveValue<...>\` | ❌ | \`'top'\` | Side of the trigger the panel is anchored to (supports responsive values) |
+| \`variant\` | \`'primary' \\| 'secondary' \\| 'accent'\` | ❌ | \`'primary'\` | Neon color variant |
+| \`size\` | \`'sm' \\| 'md' \\| 'lg' \\| ResponsiveValue<...>\` | ❌ | \`'md'\` | Panel text size / padding (supports responsive values) |
+| \`delay\` | \`number\` | ❌ | \`200\` | Delay in ms before showing on hover/focus |
+| \`disabled\` | \`boolean\` | ❌ | \`false\` | Disables hover/focus behavior entirely |
+| \`open\` | \`boolean\` | ❌ | - | Controlled visibility |
+| \`onOpenChange\` | \`(open: boolean) => void\` | ❌ | - | Fired on visibility change attempts |
+| \`className\` | \`string\` | ❌ | - | Additional CSS classes for the panel |
+
+Stories below force \`open\` for visual documentation — in real usage the tooltip opens on hover/focus.
+`,
+      },
+    },
+  },
+  tags: ['autodocs'],
+  argTypes: {
+    placement: {
+      control: { type: 'select' },
+      options: ['top', 'bottom', 'left', 'right'],
+      description: 'Side of the trigger the panel is anchored to',
+    },
+    variant: {
+      control: { type: 'select' },
+      options: ['primary', 'secondary', 'accent'],
+      description: 'Neon color variant',
+    },
+    size: {
+      control: { type: 'select' },
+      options: ['sm', 'md', 'lg'],
+      description: 'Panel text size / padding',
+    },
+    disabled: {
+      control: 'boolean',
+      description: 'Disables hover/focus behavior entirely',
+    },
+  },
+  args: {
+    content: 'Neural link status: stable.',
+    open: true,
+  },
+} satisfies Meta<typeof Tooltip>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {
+    placement: 'top',
+    variant: 'primary',
+  },
+  render: (args) => (
+    <div className="p-16">
+      <Tooltip {...args}>
+        <Button variant="primary">Run Diagnostics</Button>
+      </Tooltip>
+    </div>
+  ),
+};
+
+export const Top: Story = {
+  args: { placement: 'top', content: 'Executes protocol immediately.' },
+  render: (args) => (
+    <div className="p-16">
+      <Tooltip {...args}>
+        <Button variant="primary">Execute Protocol</Button>
+      </Tooltip>
+    </div>
+  ),
+};
+
+export const Bottom: Story = {
+  args: { placement: 'bottom', content: 'Scans local network for threats.' },
+  render: (args) => (
+    <div className="p-16">
+      <Tooltip {...args}>
+        <Button variant="secondary">Scan System</Button>
+      </Tooltip>
+    </div>
+  ),
+};
+
+export const Left: Story = {
+  args: { placement: 'left', content: 'Irreversible — proceed with caution.' },
+  render: (args) => (
+    <div className="p-16">
+      <Tooltip {...args}>
+        <Badge variant="error">DANGER</Badge>
+      </Tooltip>
+    </div>
+  ),
+};
+
+export const Right: Story = {
+  args: { placement: 'right', content: 'Neural link established.' },
+  render: (args) => (
+    <div className="p-16">
+      <Tooltip {...args}>
+        <Badge variant="success">ONLINE</Badge>
+      </Tooltip>
+    </div>
+  ),
+};
+
+export const Secondary: Story = {
+  args: { variant: 'secondary', content: 'Runs passive diagnostics.' },
+  render: (args) => (
+    <div className="p-16">
+      <Tooltip {...args}>
+        <Button variant="ghost">Run Diagnostics</Button>
+      </Tooltip>
+    </div>
+  ),
+};
+
+export const Accent: Story = {
+  args: { variant: 'accent', content: 'Highlights critical systems.' },
+  render: (args) => (
+    <div className="p-16">
+      <Tooltip {...args}>
+        <Badge variant="accent">PRIORITY</Badge>
+      </Tooltip>
+    </div>
+  ),
+};
+
+export const Small: Story = {
+  args: { size: 'sm', content: 'Compact readout.' },
+  render: (args) => (
+    <div className="p-16">
+      <Tooltip {...args}>
+        <Button size="sm">Small</Button>
+      </Tooltip>
+    </div>
+  ),
+};
+
+export const Medium: Story = {
+  args: { size: 'md', content: 'Standard readout.' },
+  render: (args) => (
+    <div className="p-16">
+      <Tooltip {...args}>
+        <Button size="md">Medium</Button>
+      </Tooltip>
+    </div>
+  ),
+};
+
+export const Large: Story = {
+  args: { size: 'lg', content: 'Expanded readout.' },
+  render: (args) => (
+    <div className="p-16">
+      <Tooltip {...args}>
+        <Button size="lg">Large</Button>
+      </Tooltip>
+    </div>
+  ),
+};
+
+export const Disabled: Story = {
+  args: { disabled: true, open: false, content: 'You should never see this.' },
+  render: (args) => (
+    <div className="p-16">
+      <Tooltip {...args}>
+        <Button variant="ghost">No Tooltip</Button>
+      </Tooltip>
+    </div>
+  ),
+};
+
+export const AllVariants: Story = {
+  render: () => (
+    <div className="flex flex-col gap-16 p-16 bg-base">
+      <div>
+        <h4 className="text-secondary font-semibold mb-4">Placements</h4>
+        <div className="flex gap-16 flex-wrap items-center">
+          <Tooltip content="Top placement" placement="top" open>
+            <Button variant="primary">Top</Button>
+          </Tooltip>
+          <Tooltip content="Bottom placement" placement="bottom" open>
+            <Button variant="primary">Bottom</Button>
+          </Tooltip>
+          <Tooltip content="Left placement" placement="left" open>
+            <Button variant="primary">Left</Button>
+          </Tooltip>
+          <Tooltip content="Right placement" placement="right" open>
+            <Button variant="primary">Right</Button>
+          </Tooltip>
+        </div>
+      </div>
+      <div>
+        <h4 className="text-secondary font-semibold mb-4">Variants</h4>
+        <div className="flex gap-16 flex-wrap items-center">
+          <Tooltip content="Primary variant" variant="primary" open>
+            <Badge variant="primary">Primary</Badge>
+          </Tooltip>
+          <Tooltip content="Secondary variant" variant="secondary" open>
+            <Badge variant="secondary">Secondary</Badge>
+          </Tooltip>
+          <Tooltip content="Accent variant" variant="accent" open>
+            <Badge variant="accent">Accent</Badge>
+          </Tooltip>
+        </div>
+      </div>
+      <div>
+        <h4 className="text-secondary font-semibold mb-4">Sizes</h4>
+        <div className="flex gap-16 flex-wrap items-center">
+          <Tooltip content="Small" size="sm" open>
+            <Button size="sm">SM</Button>
+          </Tooltip>
+          <Tooltip content="Medium" size="md" open>
+            <Button size="md">MD</Button>
+          </Tooltip>
+          <Tooltip content="Large" size="lg" open>
+            <Button size="lg">LG</Button>
+          </Tooltip>
+        </div>
+      </div>
+      <div>
+        <h4 className="text-secondary font-semibold mb-4">Disabled</h4>
+        <div className="flex gap-16 flex-wrap items-center">
+          <Tooltip content="You should never see this." disabled>
+            <Button variant="ghost">No Tooltip</Button>
+          </Tooltip>
+        </div>
+      </div>
+    </div>
+  ),
+};

--- a/src/components/Tooltip.stories.tsx
+++ b/src/components/Tooltip.stories.tsx
@@ -61,7 +61,7 @@ const [open, setOpen] = React.useState(false);
 | \`onOpenChange\` | \`(open: boolean) => void\` | ❌ | - | Fired on visibility change attempts |
 | \`className\` | \`string\` | ❌ | - | Additional CSS classes for the panel |
 
-Stories below force \`open\` for visual documentation — in real usage the tooltip opens on hover/focus.
+Most stories below force \`open\` for visual documentation. See **Interactive** for the real hover/focus/Escape behavior.
 `,
       },
     },
@@ -216,6 +216,31 @@ export const Disabled: Story = {
     <div className="p-16">
       <Tooltip {...args}>
         <Button variant="ghost">No Tooltip</Button>
+      </Tooltip>
+    </div>
+  ),
+};
+
+export const Interactive: Story = {
+  args: {
+    // Overrides meta's forced `open: true` so this story runs uncontrolled —
+    // hover or keyboard-focus the button below to see the real show/hide/delay/Escape behavior.
+    open: undefined,
+    content: 'Neural link status: stable.',
+    placement: 'top',
+    variant: 'primary',
+  },
+  parameters: {
+    docs: {
+      description: {
+        story: 'Uncontrolled — hover or Tab-focus the trigger to open, move away or press Escape to close.',
+      },
+    },
+  },
+  render: (args) => (
+    <div className="p-16">
+      <Tooltip {...args}>
+        <Button variant="primary">Hover or Focus Me</Button>
       </Tooltip>
     </div>
   ),

--- a/src/components/Tooltip.test.tsx
+++ b/src/components/Tooltip.test.tsx
@@ -1,0 +1,171 @@
+import { render, screen, fireEvent, act } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import Tooltip from './Tooltip';
+
+describe('Tooltip', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.runOnlyPendingTimers();
+    vi.useRealTimers();
+  });
+
+  it('renders the trigger without crashing', () => {
+    render(
+      <Tooltip content="Info">
+        <button>Trigger</button>
+      </Tooltip>
+    );
+    expect(screen.getByText('Trigger')).toBeInTheDocument();
+  });
+
+  it('does not render the tooltip panel initially', () => {
+    render(
+      <Tooltip content="Info">
+        <button>Trigger</button>
+      </Tooltip>
+    );
+    expect(screen.queryByRole('tooltip')).toBeNull();
+  });
+
+  it('shows the tooltip after the delay on hover', () => {
+    render(
+      <Tooltip content="Info" delay={200}>
+        <button>Trigger</button>
+      </Tooltip>
+    );
+    fireEvent.mouseEnter(screen.getByText('Trigger').parentElement as HTMLElement);
+    expect(screen.queryByRole('tooltip')).toBeNull();
+    act(() => {
+      vi.advanceTimersByTime(200);
+    });
+    expect(screen.getByRole('tooltip')).toHaveTextContent('Info');
+  });
+
+  it('hides immediately on mouse leave', () => {
+    render(
+      <Tooltip content="Info" delay={0}>
+        <button>Trigger</button>
+      </Tooltip>
+    );
+    const wrapper = screen.getByText('Trigger').parentElement as HTMLElement;
+    fireEvent.mouseEnter(wrapper);
+    act(() => {
+      vi.advanceTimersByTime(0);
+    });
+    expect(screen.getByRole('tooltip')).toBeInTheDocument();
+    fireEvent.mouseLeave(wrapper);
+    expect(screen.queryByRole('tooltip')).toBeNull();
+  });
+
+  it('shows on focus and hides on blur', () => {
+    render(
+      <Tooltip content="Info" delay={0}>
+        <button>Trigger</button>
+      </Tooltip>
+    );
+    const trigger = screen.getByText('Trigger');
+    fireEvent.focus(trigger);
+    act(() => {
+      vi.advanceTimersByTime(0);
+    });
+    expect(screen.getByRole('tooltip')).toBeInTheDocument();
+    fireEvent.blur(trigger);
+    expect(screen.queryByRole('tooltip')).toBeNull();
+  });
+
+  it('hides on Escape key', () => {
+    render(
+      <Tooltip content="Info" delay={0}>
+        <button>Trigger</button>
+      </Tooltip>
+    );
+    const wrapper = screen.getByText('Trigger').parentElement as HTMLElement;
+    fireEvent.mouseEnter(wrapper);
+    act(() => {
+      vi.advanceTimersByTime(0);
+    });
+    expect(screen.getByRole('tooltip')).toBeInTheDocument();
+    fireEvent.keyDown(wrapper, { key: 'Escape' });
+    expect(screen.queryByRole('tooltip')).toBeNull();
+  });
+
+  it('never shows when disabled', () => {
+    render(
+      <Tooltip content="Info" delay={0} disabled>
+        <button>Trigger</button>
+      </Tooltip>
+    );
+    fireEvent.mouseEnter(screen.getByText('Trigger').parentElement as HTMLElement);
+    act(() => {
+      vi.advanceTimersByTime(0);
+    });
+    expect(screen.queryByRole('tooltip')).toBeNull();
+  });
+
+  it('sets aria-describedby on the trigger when open', () => {
+    render(
+      <Tooltip content="Info" delay={0}>
+        <button>Trigger</button>
+      </Tooltip>
+    );
+    const trigger = screen.getByText('Trigger');
+    expect(trigger).not.toHaveAttribute('aria-describedby');
+    fireEvent.mouseEnter(trigger.parentElement as HTMLElement);
+    act(() => {
+      vi.advanceTimersByTime(0);
+    });
+    const tooltip = screen.getByRole('tooltip');
+    expect(trigger).toHaveAttribute('aria-describedby', tooltip.id);
+  });
+
+  it('respects controlled open state', () => {
+    const { rerender } = render(
+      <Tooltip content="Info" open={false}>
+        <button>Trigger</button>
+      </Tooltip>
+    );
+    expect(screen.queryByRole('tooltip')).toBeNull();
+    rerender(
+      <Tooltip content="Info" open={true}>
+        <button>Trigger</button>
+      </Tooltip>
+    );
+    expect(screen.getByRole('tooltip')).toBeInTheDocument();
+  });
+
+  it('calls onOpenChange but leaves visibility to the caller when controlled', () => {
+    const handleOpenChange = vi.fn();
+    render(
+      <Tooltip content="Info" open={false} onOpenChange={handleOpenChange} delay={0}>
+        <button>Trigger</button>
+      </Tooltip>
+    );
+    fireEvent.mouseEnter(screen.getByText('Trigger').parentElement as HTMLElement);
+    act(() => {
+      vi.advanceTimersByTime(0);
+    });
+    expect(handleOpenChange).toHaveBeenCalledWith(true);
+    expect(screen.queryByRole('tooltip')).toBeNull();
+  });
+
+  it('applies the variant border class to the panel', () => {
+    render(
+      <Tooltip content="Info" open variant="accent">
+        <button>Trigger</button>
+      </Tooltip>
+    );
+    expect(screen.getByRole('tooltip')).toHaveClass('border-accent');
+  });
+
+  it('applies placement classes to the panel', () => {
+    render(
+      <Tooltip content="Info" open placement="bottom">
+        <button>Trigger</button>
+      </Tooltip>
+    );
+    expect(screen.getByRole('tooltip')).toHaveClass('top-full');
+  });
+});

--- a/src/components/Tooltip.tsx
+++ b/src/components/Tooltip.tsx
@@ -1,0 +1,205 @@
+import React, { useCallback, useEffect, useId, useRef, useState } from 'react';
+import type { ResponsiveValue } from '../utils/responsive';
+import { getResponsiveClasses, isResponsiveObject, RESPONSIVE_SIZE_MAPS } from '../utils/responsive';
+import { cn } from '../utils/cn';
+
+/** Side of the trigger the tooltip panel is anchored to. */
+export type TooltipPlacement = 'top' | 'bottom' | 'left' | 'right';
+
+/**
+ * Props for the Tooltip component.
+ */
+export interface TooltipProps {
+  /**
+   * The trigger element. Must be a single React element that accepts an
+   * `aria-describedby` attribute (native elements, `Button`, `Badge`, etc).
+   * Wrap plain text/icons in a `<span tabIndex={0}>` so the trigger is
+   * keyboard-focusable — the tooltip only opens on hover or focus.
+   */
+  children: React.ReactElement<{ 'aria-describedby'?: string }>;
+  /** Content rendered inside the tooltip panel. */
+  content: React.ReactNode;
+  /**
+   * Side of the trigger the tooltip is anchored to. Supports responsive values.
+   * @default 'top'
+   */
+  placement?: ResponsiveValue<TooltipPlacement>;
+  /**
+   * Visual style, reusing the neon palette from Button/Card.
+   * @default 'primary'
+   */
+  variant?: 'primary' | 'secondary' | 'accent';
+  /**
+   * Size of the tooltip panel (text size + padding). Supports responsive values.
+   * @default 'md'
+   */
+  size?: ResponsiveValue<'sm' | 'md' | 'lg'>;
+  /**
+   * Delay in ms before the tooltip appears after hover/focus starts.
+   * Hiding is always immediate so the panel doesn't linger.
+   * @default 200
+   */
+  delay?: number;
+  /**
+   * Disables the tooltip — the trigger renders as-is with no hover/focus behavior.
+   * @default false
+   */
+  disabled?: boolean;
+  /**
+   * Controlled visibility. When set, the tooltip stops managing its own open
+   * state and `onOpenChange` becomes the only way to react to hover/focus/Escape.
+   */
+  open?: boolean;
+  /** Fired whenever hover, focus, blur, or Escape would change visibility. */
+  onOpenChange?: (open: boolean) => void;
+  /** Additional CSS classes for the tooltip panel. */
+  className?: string;
+  /** Id for the tooltip panel. Auto-generated when omitted. */
+  id?: string;
+}
+
+const PLACEMENT_CLASSES: Record<TooltipPlacement, string> = {
+  top: 'bottom-full left-1/2 -translate-x-1/2 mb-2',
+  bottom: 'top-full left-1/2 -translate-x-1/2 mt-2',
+  left: 'right-full top-1/2 -translate-y-1/2 mr-2',
+  right: 'left-full top-1/2 -translate-y-1/2 ml-2',
+};
+
+const ARROW_PLACEMENT_CLASSES: Record<TooltipPlacement, string> = {
+  top: 'top-full left-1/2 -translate-x-1/2 -mt-[5px]',
+  bottom: 'bottom-full left-1/2 -translate-x-1/2 -mb-[5px]',
+  left: 'left-full top-1/2 -translate-y-1/2 -ml-[5px]',
+  right: 'right-full top-1/2 -translate-y-1/2 -mr-[5px]',
+};
+
+const VARIANT_CLASSES: Record<'primary' | 'secondary' | 'accent', string> = {
+  primary: 'border-primary shadow-primary',
+  secondary: 'border-secondary shadow-secondary',
+  accent: 'border-accent shadow-lg-accent',
+};
+
+/**
+ * A neon-bordered popover that reveals supplemental info on hover or keyboard focus.
+ *
+ * @example
+ * <Tooltip content="Initiates a full system diagnostic scan.">
+ *   <Button variant="primary">Run Diagnostics</Button>
+ * </Tooltip>
+ *
+ * @example
+ * <Tooltip content="Cannot be undone." variant="accent" placement="right">
+ *   <Badge variant="error">DANGER</Badge>
+ * </Tooltip>
+ */
+const Tooltip: React.FC<TooltipProps> = ({
+  children,
+  content,
+  placement = 'top',
+  variant = 'primary',
+  size = 'md',
+  delay = 200,
+  disabled = false,
+  open: controlledOpen,
+  onOpenChange,
+  className = '',
+  id,
+}) => {
+  const [internalOpen, setInternalOpen] = useState(false);
+  const isControlled = controlledOpen !== undefined;
+  const isOpen = (isControlled ? controlledOpen : internalOpen) && !disabled;
+
+  const generatedId = useId();
+  const tooltipId = id || `tooltip-${generatedId}`;
+
+  const showTimeoutRef = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
+
+  const clearShowTimeout = useCallback(() => {
+    if (showTimeoutRef.current) {
+      clearTimeout(showTimeoutRef.current);
+      showTimeoutRef.current = undefined;
+    }
+  }, []);
+
+  useEffect(() => clearShowTimeout, [clearShowTimeout]);
+
+  const setOpen = useCallback(
+    (value: boolean) => {
+      if (!isControlled) setInternalOpen(value);
+      onOpenChange?.(value);
+    },
+    [isControlled, onOpenChange]
+  );
+
+  const handleShow = useCallback(() => {
+    if (disabled) return;
+    clearShowTimeout();
+    showTimeoutRef.current = setTimeout(() => setOpen(true), delay);
+  }, [disabled, delay, clearShowTimeout, setOpen]);
+
+  const handleHide = useCallback(() => {
+    clearShowTimeout();
+    setOpen(false);
+  }, [clearShowTimeout, setOpen]);
+
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent) => {
+      if (e.key === 'Escape') handleHide();
+    },
+    [handleHide]
+  );
+
+  const getSizeClasses = (size: ResponsiveValue<'sm' | 'md' | 'lg'>): string =>
+    getResponsiveClasses(size, RESPONSIVE_SIZE_MAPS.tooltip);
+
+  const basePlacement = isResponsiveObject(placement) ? placement.base ?? 'top' : placement;
+  const placementClasses =
+    getResponsiveClasses(placement, PLACEMENT_CLASSES) || PLACEMENT_CLASSES[basePlacement];
+
+  const trigger = React.cloneElement(children, {
+    'aria-describedby': isOpen ? tooltipId : undefined,
+  });
+
+  return (
+    <span
+      className="relative inline-flex w-fit"
+      onMouseEnter={handleShow}
+      onMouseLeave={handleHide}
+      onFocus={handleShow}
+      onBlur={handleHide}
+      onKeyDown={handleKeyDown}
+    >
+      {trigger}
+      {isOpen && (
+        <span
+          role="tooltip"
+          id={tooltipId}
+          className={cn(
+            'absolute z-50 overflow-hidden whitespace-nowrap rounded-md border bg-surface font-mono text-default pointer-events-none',
+            getSizeClasses(size),
+            placementClasses,
+            VARIANT_CLASSES[variant],
+            className
+          )}
+        >
+          <span
+            aria-hidden="true"
+            className="absolute inset-0 opacity-20 bg-[repeating-linear-gradient(0deg,currentColor_0px,currentColor_1px,transparent_1px,transparent_3px)]"
+          />
+          <span className="relative">{content}</span>
+          <span
+            aria-hidden="true"
+            className={cn(
+              'absolute w-2.5 h-2.5 rotate-45 bg-surface border',
+              ARROW_PLACEMENT_CLASSES[basePlacement],
+              VARIANT_CLASSES[variant]
+            )}
+          />
+        </span>
+      )}
+    </span>
+  );
+};
+
+Tooltip.displayName = 'CyberUI.Tooltip';
+
+export default Tooltip;

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -19,6 +19,7 @@ export { default as Timeline } from './Timeline';
 export { default as Steps } from './Steps';
 export { default as Divider } from './Divider';
 export { default as Checkbox } from './Checkbox';
+export { default as Tooltip } from './Tooltip';
 
 export type { CircularProgressProps } from './CircularProgress';
 export type { NotificationProps } from './Notification';
@@ -41,6 +42,7 @@ export type { TimelineProps, TimelineEvent } from './Timeline';
 export type { StepsProps, StepItem } from './Steps';
 export type { DividerProps } from './Divider';
 export type { CheckboxProps } from './Checkbox';
+export type { TooltipProps, TooltipPlacement } from './Tooltip';
 
 export type { ResponsiveValue, Breakpoint } from '../utils/responsive';
 export { getResponsiveClasses, combineResponsiveClasses, RESPONSIVE_SIZE_MAPS } from '../utils/responsive';

--- a/src/utils/responsive.ts
+++ b/src/utils/responsive.ts
@@ -133,6 +133,11 @@ export const RESPONSIVE_SIZE_MAPS = {
     md: "h-64",
     lg: "h-80",
   },
+  tooltip: {
+    sm: "text-xs px-2 py-1",
+    md: "text-sm px-3 py-1.5",
+    lg: "text-base px-4 py-2",
+  },
 } as const;
 
 // Breakpoint pixel map aligned with Tailwind defaults


### PR DESCRIPTION
Closes #2

## Summary
- Adds a `Tooltip` component: a neon-bordered popover that reveals supplemental info on hover or keyboard focus, for use around `Button`, `Badge`, or any other focusable/hoverable trigger element.
- API decisions: `placement` (`top`/`bottom`/`left`/`right`, supports `ResponsiveValue`) and `variant` (`primary`/`secondary`/`accent`) reuse the same responsive-prop and neon-palette conventions as `Button`/`Card`/`Badge` rather than inventing a new vocabulary. Positioning is done with pure Tailwind classes (no floating-ui/popper dependency, per the "no new runtime deps" rule) — the trigger is wrapped in a small relative `<span>` and the panel is absolutely positioned off one of its edges, which covers the common case of a single inline trigger.
- No scope was deferred — the issue's full ask (placement, content, trigger child, cyberpunk styling) is covered in this PR.

## Changes
- Added `Tooltip` (`src/components/Tooltip.tsx`) — controlled/uncontrolled `open` state, configurable show `delay`, `disabled`, Escape-to-dismiss, and `aria-describedby` wired onto the trigger via `React.cloneElement`.
- Added a `tooltip` entry to `RESPONSIVE_SIZE_MAPS` in `src/utils/responsive.ts`.
- Exported `Tooltip`/`TooltipProps`/`TooltipPlacement` from `src/components/index.ts`.
- Stories (`Tooltip.stories.tsx`): Default, Top/Bottom/Left/Right placements, Secondary/Accent variants, Small/Medium/Large sizes, Disabled, and an AllVariants render story (cyberpunk copy throughout, e.g. "Neural link established.", "Irreversible — proceed with caution.").
- Tests (`Tooltip.test.tsx`, 12 cases): renders trigger, hides/shows on hover with delay, shows/hides on focus/blur, hides on Escape, `disabled` suppresses all triggers, `aria-describedby` wiring, controlled `open`/`onOpenChange` behavior, variant/placement class application.
- Docs regenerated via `npm run docs:generate` (`CLAUDE.md`, `AGENT.md`, `README.md`, `public/llms.txt`, `public/component-manifest.json`, `bin/usage-content.js`) — diff reviewed, only Tooltip-related lines changed (plus a pre-existing, unrelated `packageVersion`/`generatedAt` drift already present on `master`).
- Added a CHANGELOG entry under `[Unreleased]`.

## Test plan
- [x] npm run lint / type-check / test -- --project=unit all pass
- [ ] Storybook: Default + variants + sizes + disabled + AllVariants render correctly
- [ ] Keyboard nav + screen reader smoke test

---
_Generated by [Claude Code](https://claude.ai/code/session_012bstKKn8SvUgK8uXkxq54T)_