### PR TITLE
feat: add DropdownMenu component

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -48,6 +48,7 @@ import "cyberui-2045/styles.css";
 | `TabNavigation` | Animated tab bar. |
 | `Carousel` | Image carousel. |
 | `Steps` | Multi-step progress indicator. |
+| `DropdownMenu` | Dropdown/context menu anchored to a trigger element. Arrow-key navigation, `danger` item styling, click-outside/Escape dismissal. |
 | `GradientText` | Text with cyberpunk gradient effects. |
 | `SectionTitle` | Title with decorative gradient line. |
 | `Timeline` | Vertical event history display. |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **`DropdownMenu`** component — a cyberpunk-styled dropdown/context menu anchored to a trigger element, for row actions and context menus attached to a button. Reuses `TabNavigation`'s dropdown anchor+menu pattern internally (click-outside close, viewport-aware alignment, staged open/close transition). `trigger` accepts either a single React element (cloned with the required `onClick`/`aria-*` wiring) or a render prop for full control. `items` takes `{ label, icon?, onClick?, disabled?, danger? }` entries, with `danger` reusing `Button`'s destructive-action styling. Supports controlled (`open`/`onOpenChange`) or uncontrolled usage, `align` (`start`/`end`, auto-flips on overflow), and a responsive `size` (new `RESPONSIVE_SIZE_MAPS.dropdownMenu` entry). Full keyboard support: `ArrowDown`/`ArrowUp` on the trigger opens the menu focused on the first/last item; inside the menu, `ArrowDown`/`ArrowUp` move focus via roving tabindex (wrapping, skipping disabled items), `Home`/`End` jump to the first/last item, `Enter`/`Space` activates the focused item, and `Escape` closes the menu and returns focus to the trigger.
+
 ## [2.5.0] - 2026-07-23
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,7 +34,7 @@ npm test              # All tests (unit + Storybook/Playwright)
 | Layout | Card, Modal, Divider, Accordion |
 | Feedback | Notification, Badge, Skeleton, Tooltip |
 | Progress | CircularProgress, SegmentedProgress, LinearProgress |
-| Navigation | TabNavigation, Carousel, Steps |
+| Navigation | TabNavigation, Carousel, Steps, DropdownMenu |
 | Typography | GradientText, SectionTitle |
 | Display | Timeline |
 | Media | Image, Avatar |

--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ function App() {
 | TabNavigation | Navigation | [→](https://patrickkuei.github.io/CyberUI/storybook/?path=/docs/components-tabnavigation--docs) |
 | Carousel | Navigation | [→](https://patrickkuei.github.io/CyberUI/storybook/?path=/docs/components-carousel--docs) |
 | Steps | Navigation | [→](https://patrickkuei.github.io/CyberUI/storybook/?path=/docs/components-steps--docs) |
+| DropdownMenu | Navigation | [→](https://patrickkuei.github.io/CyberUI/storybook/?path=/docs/components-dropdownmenu--docs) |
 | GradientText | Typography | [→](https://patrickkuei.github.io/CyberUI/storybook/?path=/docs/components-gradienttext--docs) |
 | SectionTitle | Typography | [→](https://patrickkuei.github.io/CyberUI/storybook/?path=/docs/components-sectiontitle--docs) |
 | Timeline | Display | [→](https://patrickkuei.github.io/CyberUI/storybook/?path=/docs/components-timeline--docs) |

--- a/bin/usage-content.js
+++ b/bin/usage-content.js
@@ -52,6 +52,7 @@ Paths below are relative to \`node_modules/cyberui-2045/\`.
 | TabNavigation | Navigation | \`dist/components/TabNavigation.d.ts\` |
 | Carousel | Navigation | \`dist/components/Carousel.d.ts\` |
 | Steps | Navigation | \`dist/components/Steps.d.ts\` |
+| DropdownMenu | Navigation | \`dist/components/DropdownMenu.d.ts\` |
 | GradientText | Typography | \`dist/components/GradientText.d.ts\` |
 | SectionTitle | Typography | \`dist/components/SectionTitle.d.ts\` |
 | Timeline | Display | \`dist/components/Timeline.d.ts\` |

--- a/public/component-manifest.json
+++ b/public/component-manifest.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 1,
-  "packageVersion": "2.4.0",
-  "generatedAt": "2026-07-23T09:48:52.965Z",
+  "packageVersion": "2.5.0",
+  "generatedAt": "2026-07-26T06:11:37.769Z",
   "categoryOrder": [
     "Forms",
     "Layout",
@@ -1501,6 +1501,95 @@
           "required": false,
           "default": "",
           "description": "Additional CSS classes."
+        }
+      ]
+    },
+    {
+      "name": "DropdownMenu",
+      "category": "Navigation",
+      "sourceFile": "src/components/DropdownMenu.tsx",
+      "displayName": "DropdownMenu",
+      "description": "A cyberpunk-styled dropdown/context menu anchored to a trigger element,\nreusing TabNavigation's dropdown anchor+menu pattern (click-outside close,\nviewport-aware alignment, staged open/close transition) with full arrow-key\nnavigation and single/danger item styling.",
+      "docSummary": "Dropdown/context menu anchored to a trigger element. Arrow-key navigation, `danger` item styling, click-outside/Escape dismissal.",
+      "storybookPath": "components-dropdownmenu--docs",
+      "manifestOverride": false,
+      "props": [
+        {
+          "name": "items",
+          "type": "DropdownMenuItem[]",
+          "required": true,
+          "default": null,
+          "description": "Actions to render, in order."
+        },
+        {
+          "name": "trigger",
+          "type": "ReactElement<unknown, string | JSXElementConstructor<any>> | ((triggerProps: DropdownMenuTriggerProps) => ReactElement<...>)",
+          "required": true,
+          "default": null,
+          "description": "The trigger that opens the menu. Pass a single React element (e.g. a\n`Button`) to have it cloned with the required `onClick`/`aria-*`\nwiring, or a render prop for full control over how those props are\napplied.\n@example // Element trigger\n<DropdownMenu trigger={<Button variant=\"secondary\">Actions</Button>} items={items} />\n@example // Render-prop trigger\n<DropdownMenu\n  trigger={(triggerProps) => <button {...triggerProps}>Actions</button>}\n  items={items}\n/>"
+        },
+        {
+          "name": "align",
+          "type": "\"start\" | \"end\" | undefined",
+          "required": false,
+          "default": "start",
+          "description": "Horizontal alignment of the menu panel relative to the trigger.\nAutomatically flips to `end` if the panel would overflow the right\nedge of the viewport when opened."
+        },
+        {
+          "name": "size",
+          "type": "ResponsiveValue<\"sm\" | \"md\" | \"lg\"> | undefined",
+          "required": false,
+          "default": "md",
+          "description": "Padding and text size of each menu item. Supports responsive values."
+        },
+        {
+          "name": "closeOnSelect",
+          "type": "boolean | undefined",
+          "required": false,
+          "default": true,
+          "description": "Whether selecting an item closes the menu."
+        },
+        {
+          "name": "open",
+          "type": "boolean | undefined",
+          "required": false,
+          "default": null,
+          "description": "Controlled open state. When set, DropdownMenu stops managing its own\nopen state and `onOpenChange` becomes the only way to react to\ntrigger clicks, item selection, Escape, and outside clicks."
+        },
+        {
+          "name": "onOpenChange",
+          "type": "((open: boolean) => void) | undefined",
+          "required": false,
+          "default": null,
+          "description": "Fired whenever a trigger click, item selection, Escape, or outside click would change visibility."
+        },
+        {
+          "name": "disabled",
+          "type": "boolean | undefined",
+          "required": false,
+          "default": false,
+          "description": "Disables the trigger and prevents the menu from opening."
+        },
+        {
+          "name": "ariaLabel",
+          "type": "string | undefined",
+          "required": false,
+          "default": "Menu",
+          "description": "Accessible label for the menu panel (`aria-label`)."
+        },
+        {
+          "name": "className",
+          "type": "string | undefined",
+          "required": false,
+          "default": "",
+          "description": "Additional CSS classes for the outer wrapper."
+        },
+        {
+          "name": "menuClassName",
+          "type": "string | undefined",
+          "required": false,
+          "default": "",
+          "description": "Additional CSS classes for the menu panel."
         }
       ]
     },

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -16,12 +16,12 @@ npm install cyberui-2045
 ```
 
 <!-- cyberui-2045:manifest:start -->
-## Components (26)
+## Components (27)
 - Forms: `Button`, `Input`, `Toggle`, `Select`, `Checkbox`, `FormField`, `RadioGroup`
 - Layout: `Card`, `Modal`, `Divider`, `Accordion`
 - Feedback: `Notification`, `Badge`, `Skeleton`, `Tooltip`
 - Progress: `CircularProgress`, `SegmentedProgress`, `LinearProgress`
-- Navigation: `TabNavigation`, `Carousel`, `Steps`
+- Navigation: `TabNavigation`, `Carousel`, `Steps`, `DropdownMenu`
 - Typography: `GradientText`, `SectionTitle`
 - Display: `Timeline`
 - Media: `Image`, `Avatar`

--- a/scripts/generate-manifest.js
+++ b/scripts/generate-manifest.js
@@ -25,7 +25,7 @@ const CATEGORY_MAP = {
   Card: 'Layout', Modal: 'Layout', Divider: 'Layout', Accordion: 'Layout',
   Notification: 'Feedback', Badge: 'Feedback', Skeleton: 'Feedback', Tooltip: 'Feedback',
   CircularProgress: 'Progress', LinearProgress: 'Progress', SegmentedProgress: 'Progress',
-  TabNavigation: 'Navigation', Carousel: 'Navigation', Steps: 'Navigation',
+  TabNavigation: 'Navigation', Carousel: 'Navigation', Steps: 'Navigation', DropdownMenu: 'Navigation',
   GradientText: 'Typography', SectionTitle: 'Typography',
   Timeline: 'Display',
   Image: 'Media', Avatar: 'Media',
@@ -62,6 +62,7 @@ const DOC_SUMMARIES = {
   Accordion: 'Collapsible section list. `mode`: `single` (default) or `multiple` open panels.',
   Avatar: 'Circular profile image with glitch-style initials fallback and an `online`/`offline`/`away` status dot.',
   RadioGroup: 'Neon-styled radio group for mutually-exclusive selection. Arrow-key navigation via roving tabindex.',
+  DropdownMenu: 'Dropdown/context menu anchored to a trigger element. Arrow-key navigation, `danger` item styling, click-outside/Escape dismissal.',
 };
 
 // SegmentedProgress exports `type SegmentedProgressProps = RadialProps | BlockProps`,

--- a/src/components/DropdownMenu.stories.tsx
+++ b/src/components/DropdownMenu.stories.tsx
@@ -1,0 +1,275 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { useState } from 'react';
+import DropdownMenu from './DropdownMenu';
+import type { DropdownMenuItem } from './DropdownMenu';
+import Button from './Button';
+
+const ROW_ACTIONS: DropdownMenuItem[] = [
+  { label: 'Edit Profile', onClick: () => {} },
+  { label: 'Duplicate Node', onClick: () => {} },
+  { label: 'Revoke Access', danger: true, onClick: () => {} },
+];
+
+const SYSTEM_ACTIONS: DropdownMenuItem[] = [
+  { label: 'Restart Subsystem', onClick: () => {} },
+  { label: 'View Access Logs', onClick: () => {} },
+  { label: 'Firmware Update', disabled: true, onClick: () => {} },
+  { label: 'Purge Local Cache', danger: true, onClick: () => {} },
+];
+
+const meta: Meta<typeof DropdownMenu> = {
+  title: 'Components/DropdownMenu',
+  component: DropdownMenu,
+  parameters: {
+    layout: 'centered',
+    docs: {
+      description: {
+        component: `A cyberpunk-styled dropdown/context menu anchored to a trigger element — for row actions, context menus, and command panels attached to a button.
+
+**Usage:**
+
+\`\`\`tsx
+import { DropdownMenu, Button } from 'cyberui-2045';
+import 'cyberui-2045/styles.css';
+
+// Row action menu
+<DropdownMenu
+  trigger={<Button variant="ghost" size="sm">⋯</Button>}
+  items={[
+    { label: 'Edit', onClick: handleEdit },
+    { label: 'Duplicate', onClick: handleDuplicate },
+    { label: 'Delete', danger: true, onClick: handleDelete },
+  ]}
+/>
+
+// Controlled, right-aligned
+const [open, setOpen] = React.useState(false);
+<DropdownMenu
+  open={open}
+  onOpenChange={setOpen}
+  align="end"
+  trigger={<Button variant="secondary">System</Button>}
+  items={systemActions}
+/>
+
+// Render-prop trigger for full control over the anchor element
+<DropdownMenu
+  trigger={(triggerProps) => <button {...triggerProps}>Actions</button>}
+  items={items}
+/>
+\`\`\`
+
+**Props:**
+
+| Prop | Type | Required | Default | Description |
+|------|------|----------|---------|-------------|
+| \`items\` | \`DropdownMenuItem[]\` | ✅ | - | Actions to render, in order |
+| \`trigger\` | \`ReactElement \\| (props) => ReactElement\` | ✅ | - | Element or render prop for the anchor that opens the menu |
+| \`align\` | \`'start' \\| 'end'\` | ❌ | \`'start'\` | Horizontal alignment of the menu panel (auto-flips if it would overflow) |
+| \`size\` | \`'sm' \\| 'md' \\| 'lg' \\| ResponsiveValue<...>\` | ❌ | \`'md'\` | Item padding/text size (supports responsive values) |
+| \`closeOnSelect\` | \`boolean\` | ❌ | \`true\` | Whether selecting an item closes the menu |
+| \`open\` | \`boolean\` | ❌ | - | Controlled visibility |
+| \`onOpenChange\` | \`(open: boolean) => void\` | ❌ | - | Fired on trigger click, item selection, Escape, or outside click |
+| \`disabled\` | \`boolean\` | ❌ | \`false\` | Disables the trigger and prevents the menu from opening |
+| \`ariaLabel\` | \`string\` | ❌ | \`'Menu'\` | Accessible label for the menu panel |
+| \`className\` | \`string\` | ❌ | - | Additional CSS classes for the outer wrapper |
+| \`menuClassName\` | \`string\` | ❌ | - | Additional CSS classes for the menu panel |
+
+**Keyboard:** \`ArrowDown\`/\`ArrowUp\` on the trigger opens the menu focused on the first/last item. Inside the menu, \`ArrowDown\`/\`ArrowUp\` move focus (wrapping), \`Home\`/\`End\` jump to the first/last item, \`Enter\`/\`Space\` activates the focused item, \`Escape\` closes and returns focus to the trigger, and clicking outside closes the menu.
+`,
+      },
+    },
+  },
+  tags: ['autodocs'],
+  argTypes: {
+    align: {
+      control: { type: 'select' },
+      options: ['start', 'end'],
+      description: 'Horizontal alignment of the menu panel',
+    },
+    size: {
+      control: { type: 'select' },
+      options: ['sm', 'md', 'lg'],
+      description: 'Item padding/text size',
+    },
+    closeOnSelect: {
+      control: 'boolean',
+      description: 'Whether selecting an item closes the menu',
+    },
+    disabled: {
+      control: 'boolean',
+      description: 'Disables the trigger and prevents the menu from opening',
+    },
+  },
+  args: {
+    items: ROW_ACTIONS,
+    open: true,
+  },
+} satisfies Meta<typeof DropdownMenu>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {
+    align: 'start',
+    size: 'md',
+  },
+  render: (args) => (
+    <div className="p-20">
+      <DropdownMenu {...args} trigger={<Button variant="secondary">Row Actions</Button>} />
+    </div>
+  ),
+};
+
+export const AlignStart: Story = {
+  args: { align: 'start' },
+  render: (args) => (
+    <div className="p-20">
+      <DropdownMenu {...args} trigger={<Button variant="secondary">Left-Aligned</Button>} />
+    </div>
+  ),
+};
+
+export const AlignEnd: Story = {
+  args: { align: 'end' },
+  render: (args) => (
+    <div className="p-20 flex justify-end w-96">
+      <DropdownMenu {...args} trigger={<Button variant="secondary">Right-Aligned</Button>} />
+    </div>
+  ),
+};
+
+export const Small: Story = {
+  args: { size: 'sm', items: SYSTEM_ACTIONS },
+  render: (args) => (
+    <div className="p-20">
+      <DropdownMenu {...args} trigger={<Button size="sm" variant="secondary">System</Button>} />
+    </div>
+  ),
+};
+
+export const Medium: Story = {
+  args: { size: 'md', items: SYSTEM_ACTIONS },
+  render: (args) => (
+    <div className="p-20">
+      <DropdownMenu {...args} trigger={<Button size="md" variant="secondary">System</Button>} />
+    </div>
+  ),
+};
+
+export const Large: Story = {
+  args: { size: 'lg', items: SYSTEM_ACTIONS },
+  render: (args) => (
+    <div className="p-20">
+      <DropdownMenu {...args} trigger={<Button size="lg" variant="secondary">System</Button>} />
+    </div>
+  ),
+};
+
+export const Disabled: Story = {
+  args: { disabled: true, open: false },
+  render: (args) => (
+    <div className="p-20">
+      <DropdownMenu {...args} trigger={<Button variant="ghost" disabled>Access Denied</Button>} />
+    </div>
+  ),
+};
+
+export const WithDangerAndDisabledItems: Story = {
+  args: { items: SYSTEM_ACTIONS },
+  parameters: {
+    docs: {
+      description: {
+        story: '"Firmware Update" is locked and skipped by keyboard navigation; "Purge Local Cache" is a destructive action styled with the `danger` treatment.',
+      },
+    },
+  },
+  render: (args) => (
+    <div className="p-20">
+      <DropdownMenu {...args} trigger={<Button variant="secondary">System</Button>} />
+    </div>
+  ),
+};
+
+export const Interactive: Story = {
+  args: {
+    // Overrides meta's forced `open: true` so this story runs uncontrolled —
+    // click the trigger below, or focus it and press ArrowDown/ArrowUp/Enter/Escape.
+    open: undefined,
+    items: ROW_ACTIONS,
+  },
+  parameters: {
+    docs: {
+      description: {
+        story: 'Uncontrolled — click to open, arrow keys to navigate, Enter/Space to select, Escape or an outside click to dismiss.',
+      },
+    },
+  },
+  render: (args) => (
+    <div className="p-20">
+      <DropdownMenu {...args} trigger={<Button variant="primary">⋯ Row Actions</Button>} />
+    </div>
+  ),
+};
+
+export const ControlledDemo: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story: 'Open state lives in the parent — useful for syncing a menu with other UI (e.g. closing it when a modal opens elsewhere).',
+      },
+    },
+  },
+  render: () => {
+    const Demo = () => {
+      const [open, setOpen] = useState(false);
+      return (
+        <div className="p-20 flex flex-col gap-3 items-start">
+          <span className="text-xs text-muted">Menu is {open ? 'OPEN' : 'CLOSED'}</span>
+          <DropdownMenu
+            open={open}
+            onOpenChange={setOpen}
+            items={ROW_ACTIONS}
+            trigger={<Button variant="secondary">Neural Link</Button>}
+          />
+        </div>
+      );
+    };
+    return <Demo />;
+  },
+};
+
+export const AllVariants: Story = {
+  render: () => (
+    <div className="flex flex-col gap-16 p-16 bg-base">
+      <div>
+        <h4 className="text-secondary font-semibold mb-4">Alignment</h4>
+        <div className="flex gap-16 flex-wrap items-start">
+          <DropdownMenu open items={ROW_ACTIONS} align="start" trigger={<Button variant="secondary">Start</Button>} />
+          <DropdownMenu open items={ROW_ACTIONS} align="end" trigger={<Button variant="secondary">End</Button>} />
+        </div>
+      </div>
+      <div>
+        <h4 className="text-secondary font-semibold mb-4">Sizes</h4>
+        <div className="flex gap-16 flex-wrap items-start">
+          <DropdownMenu open size="sm" items={ROW_ACTIONS} trigger={<Button size="sm" variant="secondary">SM</Button>} />
+          <DropdownMenu open size="md" items={ROW_ACTIONS} trigger={<Button size="md" variant="secondary">MD</Button>} />
+          <DropdownMenu open size="lg" items={ROW_ACTIONS} trigger={<Button size="lg" variant="secondary">LG</Button>} />
+        </div>
+      </div>
+      <div>
+        <h4 className="text-secondary font-semibold mb-4">Danger + Disabled Items</h4>
+        <div className="flex gap-16 flex-wrap items-start">
+          <DropdownMenu open items={SYSTEM_ACTIONS} trigger={<Button variant="secondary">System</Button>} />
+        </div>
+      </div>
+      <div>
+        <h4 className="text-secondary font-semibold mb-4">Disabled Trigger</h4>
+        <div className="flex gap-16 flex-wrap items-start">
+          <DropdownMenu disabled items={ROW_ACTIONS} trigger={<Button variant="ghost" disabled>Access Denied</Button>} />
+        </div>
+      </div>
+    </div>
+  ),
+};

--- a/src/components/DropdownMenu.stories.tsx
+++ b/src/components/DropdownMenu.stories.tsx
@@ -1,8 +1,18 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
 import { useState } from 'react';
 import DropdownMenu from './DropdownMenu';
-import type { DropdownMenuItem } from './DropdownMenu';
+import type { DropdownMenuItem, DropdownMenuProps } from './DropdownMenu';
 import Button from './Button';
+
+/**
+ * Wraps DropdownMenu with real controlled state (defaulting open) so
+ * "always open" demo stories still close correctly on outside click,
+ * Escape, or item selection instead of snapping back open.
+ */
+const OpenDemo = (props: Omit<DropdownMenuProps, 'open' | 'onOpenChange'>) => {
+  const [open, setOpen] = useState(true);
+  return <DropdownMenu {...props} open={open} onOpenChange={setOpen} />;
+};
 
 const ROW_ACTIONS: DropdownMenuItem[] = [
   { label: 'Edit Profile', onClick: () => {} },
@@ -103,7 +113,6 @@ const [open, setOpen] = React.useState(false);
   },
   args: {
     items: ROW_ACTIONS,
-    open: true,
   },
 } satisfies Meta<typeof DropdownMenu>;
 
@@ -115,54 +124,60 @@ export const Default: Story = {
     align: 'start',
     size: 'md',
   },
+  parameters: { layout: 'padded' },
   render: (args) => (
-    <div className="p-20">
-      <DropdownMenu {...args} trigger={<Button variant="secondary">Row Actions</Button>} />
+    <div className="min-h-[320px] pt-4 flex items-start justify-center">
+      <OpenDemo {...args} trigger={<Button variant="secondary">Row Actions</Button>} />
     </div>
   ),
 };
 
 export const AlignStart: Story = {
   args: { align: 'start' },
+  parameters: { layout: 'padded' },
   render: (args) => (
-    <div className="p-20">
-      <DropdownMenu {...args} trigger={<Button variant="secondary">Left-Aligned</Button>} />
+    <div className="min-h-[320px] pt-4 flex items-start justify-center">
+      <OpenDemo {...args} trigger={<Button variant="secondary">Left-Aligned</Button>} />
     </div>
   ),
 };
 
 export const AlignEnd: Story = {
   args: { align: 'end' },
+  parameters: { layout: 'padded' },
   render: (args) => (
-    <div className="p-20 flex justify-end w-96">
-      <DropdownMenu {...args} trigger={<Button variant="secondary">Right-Aligned</Button>} />
+    <div className="min-h-[320px] pt-4 flex items-start justify-end w-96">
+      <OpenDemo {...args} trigger={<Button variant="secondary">Right-Aligned</Button>} />
     </div>
   ),
 };
 
 export const Small: Story = {
-  args: { size: 'sm', items: SYSTEM_ACTIONS },
+  args: { size: 'sm' },
+  parameters: { layout: 'padded' },
   render: (args) => (
-    <div className="p-20">
-      <DropdownMenu {...args} trigger={<Button size="sm" variant="secondary">System</Button>} />
+    <div className="min-h-[320px] pt-4 flex items-start justify-center">
+      <OpenDemo {...args} trigger={<Button size="sm" variant="secondary">Row Actions</Button>} />
     </div>
   ),
 };
 
 export const Medium: Story = {
-  args: { size: 'md', items: SYSTEM_ACTIONS },
+  args: { size: 'md' },
+  parameters: { layout: 'padded' },
   render: (args) => (
-    <div className="p-20">
-      <DropdownMenu {...args} trigger={<Button size="md" variant="secondary">System</Button>} />
+    <div className="min-h-[320px] pt-4 flex items-start justify-center">
+      <OpenDemo {...args} trigger={<Button size="md" variant="secondary">Row Actions</Button>} />
     </div>
   ),
 };
 
 export const Large: Story = {
-  args: { size: 'lg', items: SYSTEM_ACTIONS },
+  args: { size: 'lg' },
+  parameters: { layout: 'padded' },
   render: (args) => (
-    <div className="p-20">
-      <DropdownMenu {...args} trigger={<Button size="lg" variant="secondary">System</Button>} />
+    <div className="min-h-[320px] pt-4 flex items-start justify-center">
+      <OpenDemo {...args} trigger={<Button size="lg" variant="secondary">Row Actions</Button>} />
     </div>
   ),
 };
@@ -179,6 +194,7 @@ export const Disabled: Story = {
 export const WithDangerAndDisabledItems: Story = {
   args: { items: SYSTEM_ACTIONS },
   parameters: {
+    layout: 'padded',
     docs: {
       description: {
         story: '"Firmware Update" is locked and skipped by keyboard navigation; "Purge Local Cache" is a destructive action styled with the `danger` treatment.',
@@ -186,17 +202,16 @@ export const WithDangerAndDisabledItems: Story = {
     },
   },
   render: (args) => (
-    <div className="p-20">
-      <DropdownMenu {...args} trigger={<Button variant="secondary">System</Button>} />
+    <div className="min-h-[320px] pt-4 flex items-start justify-center">
+      <OpenDemo {...args} trigger={<Button variant="secondary">System</Button>} />
     </div>
   ),
 };
 
 export const Interactive: Story = {
   args: {
-    // Overrides meta's forced `open: true` so this story runs uncontrolled —
-    // click the trigger below, or focus it and press ArrowDown/ArrowUp/Enter/Escape.
-    open: undefined,
+    // Runs uncontrolled (no `open` in meta.args anymore) — click the
+    // trigger below, or focus it and press ArrowDown/ArrowUp/Enter/Escape.
     items: ROW_ACTIONS,
   },
   parameters: {
@@ -241,27 +256,28 @@ export const ControlledDemo: Story = {
 };
 
 export const AllVariants: Story = {
+  parameters: { layout: 'padded' },
   render: () => (
-    <div className="flex flex-col gap-16 p-16 bg-base">
+    <div className="flex flex-col gap-64 p-16 bg-base">
       <div>
         <h4 className="text-secondary font-semibold mb-4">Alignment</h4>
         <div className="flex gap-16 flex-wrap items-start">
-          <DropdownMenu open items={ROW_ACTIONS} align="start" trigger={<Button variant="secondary">Start</Button>} />
-          <DropdownMenu open items={ROW_ACTIONS} align="end" trigger={<Button variant="secondary">End</Button>} />
+          <OpenDemo items={ROW_ACTIONS} align="start" trigger={<Button variant="secondary">Start</Button>} />
+          <OpenDemo items={ROW_ACTIONS} align="end" trigger={<Button variant="secondary">End</Button>} />
         </div>
       </div>
       <div>
         <h4 className="text-secondary font-semibold mb-4">Sizes</h4>
         <div className="flex gap-16 flex-wrap items-start">
-          <DropdownMenu open size="sm" items={ROW_ACTIONS} trigger={<Button size="sm" variant="secondary">SM</Button>} />
-          <DropdownMenu open size="md" items={ROW_ACTIONS} trigger={<Button size="md" variant="secondary">MD</Button>} />
-          <DropdownMenu open size="lg" items={ROW_ACTIONS} trigger={<Button size="lg" variant="secondary">LG</Button>} />
+          <OpenDemo size="sm" items={ROW_ACTIONS} trigger={<Button size="sm" variant="secondary">SM</Button>} />
+          <OpenDemo size="md" items={ROW_ACTIONS} trigger={<Button size="md" variant="secondary">MD</Button>} />
+          <OpenDemo size="lg" items={ROW_ACTIONS} trigger={<Button size="lg" variant="secondary">LG</Button>} />
         </div>
       </div>
       <div>
         <h4 className="text-secondary font-semibold mb-4">Danger + Disabled Items</h4>
         <div className="flex gap-16 flex-wrap items-start">
-          <DropdownMenu open items={SYSTEM_ACTIONS} trigger={<Button variant="secondary">System</Button>} />
+          <OpenDemo items={SYSTEM_ACTIONS} trigger={<Button variant="secondary">System</Button>} />
         </div>
       </div>
       <div>

--- a/src/components/DropdownMenu.test.tsx
+++ b/src/components/DropdownMenu.test.tsx
@@ -102,6 +102,13 @@ describe('DropdownMenu', () => {
     expect(screen.getByRole('menuitem', { name: 'Delete' })).toHaveClass('text-error');
   });
 
+  it('gives items a keyboard-only focus ring (focus-visible), not just outline-none', () => {
+    render(<DropdownMenu items={ITEMS} trigger={trigger} />);
+    fireEvent.click(screen.getByRole('button', { name: 'Actions' }));
+    expect(screen.getByRole('menuitem', { name: 'Edit' })).toHaveClass('focus-visible:ring-2', 'focus-visible:ring-secondary/70');
+    expect(screen.getByRole('menuitem', { name: 'Delete' })).toHaveClass('focus-visible:ring-2', 'focus-visible:ring-error/70');
+  });
+
   it('opens focused on the first item when ArrowDown is pressed on the trigger', async () => {
     render(<DropdownMenu items={ITEMS} trigger={trigger} />);
     const triggerButton = screen.getByRole('button', { name: 'Actions' });
@@ -181,6 +188,54 @@ describe('DropdownMenu', () => {
     await waitFor(() => expect(editItem).toHaveFocus());
     fireEvent.keyDown(editItem, { key: 'Enter' });
     expect(handleClick).toHaveBeenCalledTimes(1);
+  });
+
+  it('selects the focused item on Space', async () => {
+    const handleClick = vi.fn();
+    const items: DropdownMenuItem[] = [{ label: 'Edit', onClick: handleClick }];
+    render(<DropdownMenu items={items} trigger={trigger} />);
+    fireEvent.click(screen.getByRole('button', { name: 'Actions' }));
+
+    const editItem = await screen.findByRole('menuitem', { name: 'Edit' });
+    await waitFor(() => expect(editItem).toHaveFocus());
+    fireEvent.keyDown(editItem, { key: ' ' });
+    expect(handleClick).toHaveBeenCalledTimes(1);
+  });
+
+  it('closes the menu on Tab without preventing the default focus-out', async () => {
+    render(<DropdownMenu items={ITEMS} trigger={trigger} />);
+    fireEvent.click(screen.getByRole('button', { name: 'Actions' }));
+
+    const editItem = await screen.findByRole('menuitem', { name: 'Edit' });
+    await waitFor(() => expect(editItem).toHaveFocus());
+    const tabEvent = fireEvent.keyDown(editItem, { key: 'Tab' });
+
+    expect(tabEvent).toBe(true); // preventDefault() was NOT called, so Tab still moves focus natively
+    await waitFor(() => expect(screen.queryByRole('menu')).not.toBeInTheDocument());
+  });
+
+  it('composes the trigger element\'s own onClick/onKeyDown instead of overwriting them', async () => {
+    const ownOnClick = vi.fn();
+    const ownOnKeyDown = vi.fn();
+    render(
+      <DropdownMenu
+        items={ITEMS}
+        trigger={
+          <Button variant="secondary" onClick={ownOnClick} onKeyDown={ownOnKeyDown}>
+            Actions
+          </Button>
+        }
+      />
+    );
+    const triggerButton = screen.getByRole('button', { name: 'Actions' });
+
+    fireEvent.click(triggerButton);
+    expect(ownOnClick).toHaveBeenCalledTimes(1);
+    expect(screen.getByRole('menu')).toBeInTheDocument();
+
+    fireEvent.keyDown(triggerButton, { key: 'Escape' });
+    expect(ownOnKeyDown).toHaveBeenCalledTimes(1);
+    await waitFor(() => expect(screen.queryByRole('menu')).not.toBeInTheDocument());
   });
 
   it('closes on Escape and returns focus to the trigger', async () => {

--- a/src/components/DropdownMenu.test.tsx
+++ b/src/components/DropdownMenu.test.tsx
@@ -1,0 +1,236 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import DropdownMenu from './DropdownMenu';
+import type { DropdownMenuItem } from './DropdownMenu';
+import Button from './Button';
+
+const ITEMS: DropdownMenuItem[] = [
+  { label: 'Edit', onClick: vi.fn() },
+  { label: 'Duplicate', onClick: vi.fn() },
+  { label: 'Delete', danger: true, onClick: vi.fn() },
+];
+
+const trigger = <Button variant="secondary">Actions</Button>;
+
+describe('DropdownMenu', () => {
+  it('renders the trigger without crashing and keeps the menu out of the DOM while closed', () => {
+    render(<DropdownMenu items={ITEMS} trigger={trigger} />);
+    expect(screen.getByRole('button', { name: 'Actions' })).toBeInTheDocument();
+    expect(screen.queryByRole('menu')).not.toBeInTheDocument();
+  });
+
+  it('wires aria-haspopup/aria-expanded/aria-controls on the trigger', () => {
+    render(<DropdownMenu items={ITEMS} trigger={trigger} />);
+    const triggerButton = screen.getByRole('button', { name: 'Actions' });
+    expect(triggerButton).toHaveAttribute('aria-haspopup', 'menu');
+    expect(triggerButton).toHaveAttribute('aria-expanded', 'false');
+
+    fireEvent.click(triggerButton);
+    const menu = screen.getByRole('menu');
+    expect(triggerButton).toHaveAttribute('aria-expanded', 'true');
+    expect(triggerButton.getAttribute('aria-controls')).toBe(menu.id);
+  });
+
+  it('opens the menu on trigger click and shows all items as menuitems', () => {
+    render(<DropdownMenu items={ITEMS} trigger={trigger} />);
+    fireEvent.click(screen.getByRole('button', { name: 'Actions' }));
+    expect(screen.getAllByRole('menuitem')).toHaveLength(3);
+    expect(screen.getByRole('menuitem', { name: 'Edit' })).toBeInTheDocument();
+    expect(screen.getByRole('menuitem', { name: 'Delete' })).toBeInTheDocument();
+  });
+
+  it('closes the menu on a second trigger click', async () => {
+    render(<DropdownMenu items={ITEMS} trigger={trigger} />);
+    const triggerButton = screen.getByRole('button', { name: 'Actions' });
+    fireEvent.click(triggerButton);
+    expect(screen.getByRole('menu')).toBeInTheDocument();
+
+    fireEvent.click(triggerButton);
+    await waitFor(() => expect(triggerButton).toHaveAttribute('aria-expanded', 'false'));
+    expect(screen.queryByRole('menu')).not.toBeInTheDocument();
+  });
+
+  it('closes when clicking outside the menu', async () => {
+    render(<DropdownMenu items={ITEMS} trigger={trigger} />);
+    fireEvent.click(screen.getByRole('button', { name: 'Actions' }));
+    expect(screen.getByRole('menu')).toBeInTheDocument();
+
+    fireEvent.mouseDown(document.body);
+    await waitFor(() => expect(screen.queryByRole('menu')).not.toBeInTheDocument());
+  });
+
+  it('calls the item onClick handler and closes the menu by default', async () => {
+    const handleClick = vi.fn();
+    const items: DropdownMenuItem[] = [{ label: 'Edit', onClick: handleClick }];
+    render(<DropdownMenu items={items} trigger={trigger} />);
+    fireEvent.click(screen.getByRole('button', { name: 'Actions' }));
+
+    fireEvent.click(screen.getByRole('menuitem', { name: 'Edit' }));
+    expect(handleClick).toHaveBeenCalledTimes(1);
+    await waitFor(() => expect(screen.queryByRole('menu')).not.toBeInTheDocument());
+  });
+
+  it('keeps the menu open after selecting when closeOnSelect is false', () => {
+    const handleClick = vi.fn();
+    const items: DropdownMenuItem[] = [{ label: 'Edit', onClick: handleClick }];
+    render(<DropdownMenu items={items} trigger={trigger} closeOnSelect={false} />);
+    fireEvent.click(screen.getByRole('button', { name: 'Actions' }));
+
+    fireEvent.click(screen.getByRole('menuitem', { name: 'Edit' }));
+    expect(handleClick).toHaveBeenCalledTimes(1);
+    expect(screen.getByRole('menu')).toBeInTheDocument();
+  });
+
+  it('does not fire onClick and stays disabled for a disabled item', () => {
+    const handleClick = vi.fn();
+    const items: DropdownMenuItem[] = [
+      { label: 'Edit', onClick: vi.fn() },
+      { label: 'Locked', disabled: true, onClick: handleClick },
+    ];
+    render(<DropdownMenu items={items} trigger={trigger} />);
+    fireEvent.click(screen.getByRole('button', { name: 'Actions' }));
+
+    const lockedItem = screen.getByRole('menuitem', { name: 'Locked' });
+    expect(lockedItem).toBeDisabled();
+    fireEvent.click(lockedItem);
+    expect(handleClick).not.toHaveBeenCalled();
+  });
+
+  it('applies the danger treatment class to items marked danger', () => {
+    render(<DropdownMenu items={ITEMS} trigger={trigger} />);
+    fireEvent.click(screen.getByRole('button', { name: 'Actions' }));
+    expect(screen.getByRole('menuitem', { name: 'Delete' })).toHaveClass('text-error');
+  });
+
+  it('opens focused on the first item when ArrowDown is pressed on the trigger', async () => {
+    render(<DropdownMenu items={ITEMS} trigger={trigger} />);
+    const triggerButton = screen.getByRole('button', { name: 'Actions' });
+    fireEvent.keyDown(triggerButton, { key: 'ArrowDown' });
+
+    const editItem = await screen.findByRole('menuitem', { name: 'Edit' });
+    await waitFor(() => expect(editItem).toHaveFocus());
+  });
+
+  it('opens focused on the last item when ArrowUp is pressed on the trigger', async () => {
+    render(<DropdownMenu items={ITEMS} trigger={trigger} />);
+    const triggerButton = screen.getByRole('button', { name: 'Actions' });
+    fireEvent.keyDown(triggerButton, { key: 'ArrowUp' });
+
+    const deleteItem = await screen.findByRole('menuitem', { name: 'Delete' });
+    await waitFor(() => expect(deleteItem).toHaveFocus());
+  });
+
+  it('moves focus between items with ArrowDown/ArrowUp, wrapping at the ends', async () => {
+    render(<DropdownMenu items={ITEMS} trigger={trigger} />);
+    fireEvent.click(screen.getByRole('button', { name: 'Actions' }));
+
+    const editItem = await screen.findByRole('menuitem', { name: 'Edit' });
+    const duplicateItem = screen.getByRole('menuitem', { name: 'Duplicate' });
+    const deleteItem = screen.getByRole('menuitem', { name: 'Delete' });
+
+    await waitFor(() => expect(editItem).toHaveFocus());
+    fireEvent.keyDown(editItem, { key: 'ArrowDown' });
+    expect(duplicateItem).toHaveFocus();
+    fireEvent.keyDown(duplicateItem, { key: 'ArrowDown' });
+    expect(deleteItem).toHaveFocus();
+    fireEvent.keyDown(deleteItem, { key: 'ArrowDown' });
+    expect(editItem).toHaveFocus();
+
+    fireEvent.keyDown(editItem, { key: 'ArrowUp' });
+    expect(deleteItem).toHaveFocus();
+  });
+
+  it('skips disabled items during arrow-key navigation', async () => {
+    const items: DropdownMenuItem[] = [
+      { label: 'Edit', onClick: vi.fn() },
+      { label: 'Locked', disabled: true, onClick: vi.fn() },
+      { label: 'Delete', onClick: vi.fn() },
+    ];
+    render(<DropdownMenu items={items} trigger={trigger} />);
+    fireEvent.click(screen.getByRole('button', { name: 'Actions' }));
+
+    const editItem = await screen.findByRole('menuitem', { name: 'Edit' });
+    const deleteItem = screen.getByRole('menuitem', { name: 'Delete' });
+    await waitFor(() => expect(editItem).toHaveFocus());
+
+    fireEvent.keyDown(editItem, { key: 'ArrowDown' });
+    expect(deleteItem).toHaveFocus();
+  });
+
+  it('jumps to the first/last item on Home/End', async () => {
+    render(<DropdownMenu items={ITEMS} trigger={trigger} />);
+    fireEvent.click(screen.getByRole('button', { name: 'Actions' }));
+
+    const editItem = await screen.findByRole('menuitem', { name: 'Edit' });
+    const deleteItem = screen.getByRole('menuitem', { name: 'Delete' });
+    await waitFor(() => expect(editItem).toHaveFocus());
+
+    fireEvent.keyDown(editItem, { key: 'End' });
+    expect(deleteItem).toHaveFocus();
+    fireEvent.keyDown(deleteItem, { key: 'Home' });
+    expect(editItem).toHaveFocus();
+  });
+
+  it('selects the focused item on Enter', async () => {
+    const handleClick = vi.fn();
+    const items: DropdownMenuItem[] = [{ label: 'Edit', onClick: handleClick }];
+    render(<DropdownMenu items={items} trigger={trigger} />);
+    fireEvent.click(screen.getByRole('button', { name: 'Actions' }));
+
+    const editItem = await screen.findByRole('menuitem', { name: 'Edit' });
+    await waitFor(() => expect(editItem).toHaveFocus());
+    fireEvent.keyDown(editItem, { key: 'Enter' });
+    expect(handleClick).toHaveBeenCalledTimes(1);
+  });
+
+  it('closes on Escape and returns focus to the trigger', async () => {
+    render(<DropdownMenu items={ITEMS} trigger={trigger} />);
+    const triggerButton = screen.getByRole('button', { name: 'Actions' });
+    fireEvent.click(triggerButton);
+
+    const editItem = await screen.findByRole('menuitem', { name: 'Edit' });
+    await waitFor(() => expect(editItem).toHaveFocus());
+    fireEvent.keyDown(editItem, { key: 'Escape' });
+
+    await waitFor(() => expect(screen.queryByRole('menu')).not.toBeInTheDocument());
+    expect(triggerButton).toHaveFocus();
+  });
+
+  it('never opens when disabled', () => {
+    render(<DropdownMenu items={ITEMS} trigger={trigger} disabled />);
+    fireEvent.click(screen.getByRole('button', { name: 'Actions' }));
+    expect(screen.queryByRole('menu')).not.toBeInTheDocument();
+  });
+
+  it('respects controlled open/onOpenChange without self-managing state', () => {
+    const handleOpenChange = vi.fn();
+    const { rerender } = render(
+      <DropdownMenu items={ITEMS} trigger={trigger} open={false} onOpenChange={handleOpenChange} />
+    );
+    fireEvent.click(screen.getByRole('button', { name: 'Actions' }));
+    expect(handleOpenChange).toHaveBeenCalledWith(true);
+    expect(screen.queryByRole('menu')).not.toBeInTheDocument();
+
+    rerender(<DropdownMenu items={ITEMS} trigger={trigger} open onOpenChange={handleOpenChange} />);
+    expect(screen.getByRole('menu')).toBeInTheDocument();
+  });
+
+  it('supports a render-prop trigger', () => {
+    render(
+      <DropdownMenu
+        items={ITEMS}
+        trigger={(triggerProps) => <button {...triggerProps}>Custom Trigger</button>}
+      />
+    );
+    const customTrigger = screen.getByRole('button', { name: 'Custom Trigger' });
+    expect(customTrigger).toHaveAttribute('aria-haspopup', 'menu');
+    fireEvent.click(customTrigger);
+    expect(screen.getByRole('menu')).toBeInTheDocument();
+  });
+
+  it('applies a responsive size prop without crashing', () => {
+    render(<DropdownMenu items={ITEMS} trigger={trigger} size={{ base: 'sm', md: 'lg' }} />);
+    fireEvent.click(screen.getByRole('button', { name: 'Actions' }));
+    expect(screen.getByRole('menu')).toBeInTheDocument();
+  });
+});

--- a/src/components/DropdownMenu.tsx
+++ b/src/components/DropdownMenu.tsx
@@ -1,0 +1,388 @@
+import React, { useCallback, useEffect, useId, useRef, useState } from 'react';
+import type { ResponsiveValue } from '../utils/responsive';
+import { getResponsiveClasses, RESPONSIVE_SIZE_MAPS } from '../utils/responsive';
+import { cn } from '../utils/cn';
+
+/**
+ * A single action within a DropdownMenu.
+ */
+export interface DropdownMenuItem {
+  /** Label text rendered for the item. */
+  label: string;
+  /** Optional icon rendered to the left of the label. */
+  icon?: React.ReactNode;
+  /** Fired when the item is activated by click, Enter, or Space. */
+  onClick?: () => void;
+  /**
+   * Disables this item. It renders dimmed and is skipped by arrow-key
+   * navigation (same as a disabled `<button>`).
+   * @default false
+   */
+  disabled?: boolean;
+  /**
+   * Styles the item as a destructive action (red text, matching Button's
+   * `danger` variant vocabulary) instead of the default neutral treatment.
+   * @default false
+   */
+  danger?: boolean;
+}
+
+/** Props injected onto the trigger element or passed to the trigger render prop. */
+export interface DropdownMenuTriggerProps {
+  'aria-haspopup': 'menu';
+  'aria-expanded': boolean;
+  'aria-controls': string;
+  onClick: () => void;
+  onKeyDown: (event: React.KeyboardEvent) => void;
+}
+
+/**
+ * Props for the DropdownMenu component.
+ */
+export interface DropdownMenuProps {
+  /** Actions to render, in order. */
+  items: DropdownMenuItem[];
+  /**
+   * The trigger that opens the menu. Pass a single React element (e.g. a
+   * `Button`) to have it cloned with the required `onClick`/`aria-*`
+   * wiring, or a render prop for full control over how those props are
+   * applied.
+   *
+   * @example
+   * // Element trigger
+   * <DropdownMenu trigger={<Button variant="secondary">Actions</Button>} items={items} />
+   *
+   * @example
+   * // Render-prop trigger
+   * <DropdownMenu
+   *   trigger={(triggerProps) => <button {...triggerProps}>Actions</button>}
+   *   items={items}
+   * />
+   */
+  trigger: React.ReactElement | ((triggerProps: DropdownMenuTriggerProps) => React.ReactElement);
+  /**
+   * Horizontal alignment of the menu panel relative to the trigger.
+   * Automatically flips to `end` if the panel would overflow the right
+   * edge of the viewport when opened.
+   * @default 'start'
+   */
+  align?: 'start' | 'end';
+  /**
+   * Padding and text size of each menu item. Supports responsive values.
+   * @default 'md'
+   */
+  size?: ResponsiveValue<'sm' | 'md' | 'lg'>;
+  /**
+   * Whether selecting an item closes the menu.
+   * @default true
+   */
+  closeOnSelect?: boolean;
+  /**
+   * Controlled open state. When set, DropdownMenu stops managing its own
+   * open state and `onOpenChange` becomes the only way to react to
+   * trigger clicks, item selection, Escape, and outside clicks.
+   */
+  open?: boolean;
+  /** Fired whenever a trigger click, item selection, Escape, or outside click would change visibility. */
+  onOpenChange?: (open: boolean) => void;
+  /** Disables the trigger and prevents the menu from opening. */
+  disabled?: boolean;
+  /** Accessible label for the menu panel (`aria-label`). @default 'Menu' */
+  ariaLabel?: string;
+  /** Additional CSS classes for the outer wrapper. */
+  className?: string;
+  /** Additional CSS classes for the menu panel. */
+  menuClassName?: string;
+}
+
+const isElement = (
+  trigger: DropdownMenuProps['trigger']
+): trigger is React.ReactElement => typeof trigger !== 'function';
+
+/**
+ * A cyberpunk-styled dropdown/context menu anchored to a trigger element,
+ * reusing TabNavigation's dropdown anchor+menu pattern (click-outside close,
+ * viewport-aware alignment, staged open/close transition) with full arrow-key
+ * navigation and single/danger item styling.
+ *
+ * @example
+ * // Row action menu
+ * <DropdownMenu
+ *   trigger={<Button variant="ghost" size="sm">⋯</Button>}
+ *   items={[
+ *     { label: 'Edit', onClick: handleEdit },
+ *     { label: 'Duplicate', onClick: handleDuplicate },
+ *     { label: 'Delete', danger: true, onClick: handleDelete },
+ *   ]}
+ * />
+ *
+ * @example
+ * // Controlled, right-aligned
+ * <DropdownMenu
+ *   open={open}
+ *   onOpenChange={setOpen}
+ *   align="end"
+ *   trigger={<Button variant="secondary">System</Button>}
+ *   items={systemActions}
+ * />
+ */
+const DropdownMenu: React.FC<DropdownMenuProps> = ({
+  items,
+  trigger,
+  align = 'start',
+  size = 'md',
+  closeOnSelect = true,
+  open: controlledOpen,
+  onOpenChange,
+  disabled = false,
+  ariaLabel = 'Menu',
+  className = '',
+  menuClassName = '',
+}) => {
+  const [internalOpen, setInternalOpen] = useState(false);
+  const [isOpening, setIsOpening] = useState(false);
+  const [isClosing, setIsClosing] = useState(false);
+  const [alignEnd, setAlignEnd] = useState(align === 'end');
+  const [activeIndex, setActiveIndex] = useState(0);
+
+  const isControlled = controlledOpen !== undefined;
+  const open = isControlled ? controlledOpen : internalOpen;
+
+  const generatedId = useId();
+  const menuId = `dropdown-menu-${generatedId}`;
+
+  const wrapperRef = useRef<HTMLDivElement | null>(null);
+  const menuRef = useRef<HTMLDivElement | null>(null);
+  const itemRefs = useRef<(HTMLButtonElement | null)[]>([]);
+  const triggerRef = useRef<HTMLElement | null>(null);
+
+  const enabledIndices = items
+    .map((item, i) => (item.disabled ? -1 : i))
+    .filter((i) => i !== -1);
+
+  const setOpen = useCallback(
+    (value: boolean) => {
+      if (!isControlled) setInternalOpen(value);
+      onOpenChange?.(value);
+    },
+    [isControlled, onOpenChange]
+  );
+
+  const closeMenu = useCallback(
+    (focusTrigger: boolean) => {
+      setIsClosing(true);
+      setTimeout(() => {
+        setOpen(false);
+        setIsClosing(false);
+        if (focusTrigger) triggerRef.current?.focus();
+      }, 180);
+    },
+    [setOpen]
+  );
+
+  const openMenu = useCallback(
+    (focusIndex: number) => {
+      setIsOpening(true);
+      setActiveIndex(focusIndex);
+      setOpen(true);
+      setTimeout(() => setIsOpening(false), 30);
+    },
+    [setOpen]
+  );
+
+  const toggleMenu = useCallback(() => {
+    if (disabled) return;
+    if (open) {
+      closeMenu(false);
+    } else {
+      openMenu(enabledIndices[0] ?? 0);
+    }
+  }, [disabled, open, closeMenu, openMenu, enabledIndices]);
+
+  useEffect(() => {
+    if (!open) return;
+    const handleMouseDown = (e: MouseEvent) => {
+      if (wrapperRef.current && !wrapperRef.current.contains(e.target as Node)) {
+        closeMenu(false);
+      }
+    };
+    document.addEventListener('mousedown', handleMouseDown);
+    return () => document.removeEventListener('mousedown', handleMouseDown);
+  }, [open, closeMenu]);
+
+  useEffect(() => {
+    if (!open) return;
+    const el = menuRef.current;
+    if (!el) return;
+    const rect = el.getBoundingClientRect();
+    setAlignEnd(align === 'end' || rect.right > window.innerWidth);
+  }, [open, align]);
+
+  useEffect(() => {
+    if (open && !isOpening) {
+      itemRefs.current[activeIndex]?.focus();
+    }
+  }, [open, isOpening, activeIndex]);
+
+  const selectItem = (item: DropdownMenuItem) => {
+    if (item.disabled) return;
+    item.onClick?.();
+    if (closeOnSelect) closeMenu(true);
+  };
+
+  const handleTriggerKeyDown = (event: React.KeyboardEvent) => {
+    if (disabled) return;
+    if (event.key === 'ArrowDown') {
+      event.preventDefault();
+      openMenu(enabledIndices[0] ?? 0);
+    } else if (event.key === 'ArrowUp') {
+      event.preventDefault();
+      openMenu(enabledIndices[enabledIndices.length - 1] ?? 0);
+    } else if (event.key === 'Escape' && open) {
+      event.preventDefault();
+      closeMenu(false);
+    }
+  };
+
+  const handleItemKeyDown = (event: React.KeyboardEvent<HTMLButtonElement>, index: number) => {
+    if (enabledIndices.length === 0) return;
+    const currentPos = enabledIndices.indexOf(index);
+
+    switch (event.key) {
+      case 'ArrowDown': {
+        event.preventDefault();
+        const nextPos = (currentPos + 1) % enabledIndices.length;
+        setActiveIndex(enabledIndices[nextPos]);
+        break;
+      }
+      case 'ArrowUp': {
+        event.preventDefault();
+        const prevPos = (currentPos - 1 + enabledIndices.length) % enabledIndices.length;
+        setActiveIndex(enabledIndices[prevPos]);
+        break;
+      }
+      case 'Home': {
+        event.preventDefault();
+        setActiveIndex(enabledIndices[0]);
+        break;
+      }
+      case 'End': {
+        event.preventDefault();
+        setActiveIndex(enabledIndices[enabledIndices.length - 1]);
+        break;
+      }
+      case 'Enter':
+      case ' ': {
+        event.preventDefault();
+        selectItem(items[index]);
+        break;
+      }
+      case 'Escape': {
+        event.preventDefault();
+        closeMenu(true);
+        break;
+      }
+      case 'Tab': {
+        closeMenu(false);
+        break;
+      }
+      default:
+        break;
+    }
+  };
+
+  const sizeClasses = getResponsiveClasses(size, RESPONSIVE_SIZE_MAPS.dropdownMenu);
+
+  const triggerProps: DropdownMenuTriggerProps = {
+    'aria-haspopup': 'menu',
+    'aria-expanded': open,
+    'aria-controls': menuId,
+    onClick: toggleMenu,
+    onKeyDown: handleTriggerKeyDown,
+  };
+
+  const renderedTrigger = isElement(trigger)
+    ? React.cloneElement(trigger, {
+        ...triggerProps,
+        'aria-disabled': disabled || undefined,
+        ref: (node: HTMLElement | null) => {
+          triggerRef.current = node;
+          const { ref } = trigger as React.ReactElement & { ref?: React.Ref<HTMLElement> };
+          if (typeof ref === 'function') ref(node);
+          else if (ref && typeof ref === 'object') (ref as React.RefObject<HTMLElement | null>).current = node;
+        },
+      })
+    : trigger(triggerProps);
+
+  return (
+    <div ref={wrapperRef} className={cn('relative inline-block', className)}>
+      {!isElement(trigger) ? (
+        <span
+          ref={(node) => {
+            triggerRef.current = node;
+          }}
+        >
+          {renderedTrigger}
+        </span>
+      ) : (
+        renderedTrigger
+      )}
+
+      {(open || isClosing) && (
+        <div
+          ref={menuRef}
+          id={menuId}
+          role="menu"
+          aria-label={ariaLabel}
+          aria-hidden={!open}
+          className={cn(
+            'absolute z-50 mt-2 min-w-44 overflow-hidden rounded-lg border-2 border-border-default bg-surface shadow-secondary',
+            alignEnd ? 'right-0' : 'left-0',
+            'transition-transform transition-opacity duration-200 ease-[cubic-bezier(.2,0,0,1)] transform-gpu origin-top will-change-transform will-change-opacity',
+            isOpening || isClosing
+              ? 'pointer-events-none scale-y-0 opacity-0'
+              : 'pointer-events-auto scale-y-100 opacity-100',
+            menuClassName
+          )}
+        >
+          <div className="py-1">
+            {items.map((item, index) => (
+              <button
+                key={`${item.label}-${index}`}
+                ref={(el) => {
+                  itemRefs.current[index] = el;
+                }}
+                type="button"
+                role="menuitem"
+                disabled={item.disabled}
+                tabIndex={activeIndex === index ? 0 : -1}
+                onClick={() => selectItem(item)}
+                onKeyDown={(e) => handleItemKeyDown(e, index)}
+                onMouseEnter={() => !item.disabled && setActiveIndex(index)}
+                className={cn(
+                  'flex w-full items-center gap-2 text-left font-bold outline-none transition-colors duration-200',
+                  sizeClasses,
+                  item.disabled
+                    ? 'cursor-not-allowed text-muted/40'
+                    : cn(
+                        'cursor-pointer',
+                        item.danger
+                          ? 'text-error hover:bg-error hover:text-base'
+                          : 'text-default hover:bg-base/70 hover:text-secondary'
+                      )
+                )}
+              >
+                {item.icon}
+                <span>{item.label}</span>
+              </button>
+            ))}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+};
+
+DropdownMenu.displayName = 'CyberUI.DropdownMenu';
+
+export default DropdownMenu;

--- a/src/components/DropdownMenu.tsx
+++ b/src/components/DropdownMenu.tsx
@@ -46,7 +46,8 @@ export interface DropdownMenuProps {
    * The trigger that opens the menu. Pass a single React element (e.g. a
    * `Button`) to have it cloned with the required `onClick`/`aria-*`
    * wiring, or a render prop for full control over how those props are
-   * applied.
+   * applied. If the element already has its own `onClick`/`onKeyDown`,
+   * they're called first, before the dropdown's own handling runs.
    *
    * @example
    * // Element trigger
@@ -155,6 +156,15 @@ const DropdownMenu: React.FC<DropdownMenuProps> = ({
   const menuRef = useRef<HTMLDivElement | null>(null);
   const itemRefs = useRef<(HTMLButtonElement | null)[]>([]);
   const triggerRef = useRef<HTMLElement | null>(null);
+  const closeTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const openTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    return () => {
+      if (closeTimeoutRef.current) clearTimeout(closeTimeoutRef.current);
+      if (openTimeoutRef.current) clearTimeout(openTimeoutRef.current);
+    };
+  }, []);
 
   const enabledIndices = items
     .map((item, i) => (item.disabled ? -1 : i))
@@ -171,7 +181,8 @@ const DropdownMenu: React.FC<DropdownMenuProps> = ({
   const closeMenu = useCallback(
     (focusTrigger: boolean) => {
       setIsClosing(true);
-      setTimeout(() => {
+      if (closeTimeoutRef.current) clearTimeout(closeTimeoutRef.current);
+      closeTimeoutRef.current = setTimeout(() => {
         setOpen(false);
         setIsClosing(false);
         if (focusTrigger) triggerRef.current?.focus();
@@ -185,7 +196,8 @@ const DropdownMenu: React.FC<DropdownMenuProps> = ({
       setIsOpening(true);
       setActiveIndex(focusIndex);
       setOpen(true);
-      setTimeout(() => setIsOpening(false), 30);
+      if (openTimeoutRef.current) clearTimeout(openTimeoutRef.current);
+      openTimeoutRef.current = setTimeout(() => setIsOpening(false), 30);
     },
     [setOpen]
   );
@@ -304,6 +316,14 @@ const DropdownMenu: React.FC<DropdownMenuProps> = ({
   const renderedTrigger = isElement(trigger)
     ? React.cloneElement(trigger, {
         ...triggerProps,
+        onClick: (event: React.MouseEvent) => {
+          (trigger.props as { onClick?: React.MouseEventHandler }).onClick?.(event);
+          toggleMenu();
+        },
+        onKeyDown: (event: React.KeyboardEvent) => {
+          (trigger.props as { onKeyDown?: React.KeyboardEventHandler }).onKeyDown?.(event);
+          handleTriggerKeyDown(event);
+        },
         'aria-disabled': disabled || undefined,
         ref: (node: HTMLElement | null) => {
           triggerRef.current = node;
@@ -367,8 +387,8 @@ const DropdownMenu: React.FC<DropdownMenuProps> = ({
                     : cn(
                         'cursor-pointer',
                         item.danger
-                          ? 'text-error hover:bg-error hover:text-base'
-                          : 'text-default hover:bg-base/70 hover:text-secondary'
+                          ? 'text-error hover:bg-error hover:text-base focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-error/70'
+                          : 'text-default hover:bg-base/70 hover:text-secondary focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-secondary/70'
                       )
                 )}
               >

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -24,6 +24,7 @@ export { default as FormField } from './FormField';
 export { default as Accordion } from './Accordion';
 export { default as Avatar } from './Avatar';
 export { default as RadioGroup } from './RadioGroup';
+export { default as DropdownMenu } from './DropdownMenu';
 
 export type { CircularProgressProps } from './CircularProgress';
 export type { NotificationProps } from './Notification';
@@ -51,6 +52,7 @@ export type { FormFieldProps, FormFieldState, FormFieldChildProps } from './Form
 export type { AccordionProps, AccordionItem } from './Accordion';
 export type { AvatarProps, AvatarStatus } from './Avatar';
 export type { RadioGroupProps, RadioOption } from './RadioGroup';
+export type { DropdownMenuProps, DropdownMenuItem, DropdownMenuTriggerProps } from './DropdownMenu';
 
 export type { ResponsiveValue, Breakpoint } from '../utils/responsive';
 export { getResponsiveClasses, combineResponsiveClasses, RESPONSIVE_SIZE_MAPS } from '../utils/responsive';

--- a/src/utils/responsive.ts
+++ b/src/utils/responsive.ts
@@ -161,6 +161,11 @@ export const RESPONSIVE_SIZE_MAPS = {
     lg: "w-16 h-16 text-lg",
     xl: "w-24 h-24 text-2xl",
   },
+  dropdownMenu: {
+    sm: "px-3 py-1.5 text-sm",
+    md: "px-4 py-2 text-base",
+    lg: "px-5 py-2.5 text-lg",
+  },
 } as const;
 
 // Breakpoint pixel map aligned with Tailwind defaults


### PR DESCRIPTION
Closes #10

## Summary
- Adds a `DropdownMenu` component: a cyberpunk-styled dropdown/context menu anchored to a trigger element, for row action menus and context menus attached to a button (e.g. a row's "..." menu).
- API decisions: `trigger` accepts either a single React element (cloned with the required `onClick`/`aria-*` wiring, matching `Tooltip`'s `cloneElement` pattern) or a render prop, covering the issue's "trigger element (render prop or child)" ask directly. `items` takes `{ label, icon?, onClick?, disabled?, danger? }` entries — `danger` reuses `Button`'s destructive-action color treatment rather than inventing new vocabulary. Internally reuses `TabNavigation`'s `TabDropdown` anchor+menu pattern (click-outside close via a wrapper-ref `mousedown` listener, viewport-aware `alignEnd` flip via `getBoundingClientRect`, staged open/close CSS transition) per the issue's suggestion to share that pattern rather than rebuild it, and matches Modal/Select's existing neon-bordered overlay treatment. Keyboard navigation inside the menu uses a roving-tabindex implementation (same shape as `Accordion`/`RadioGroup`'s navigation).
- No scope was deferred — the issue's full ask (trigger element, `items` with label/icon/onClick/disabled/danger, arrow-key navigation with Enter/Escape, click-outside/Escape dismissal, neon menu panel with hover glow) is covered in this PR.

## Changes
- Added `DropdownMenu` (`src/components/DropdownMenu.tsx`) — `items`, `trigger` (element or render prop), `align` (`start`/`end`, auto-flip), responsive `size`, `closeOnSelect`, controlled `open`/`onOpenChange`, `disabled`, `ariaLabel`, `className`, `menuClassName`.
- Added a `dropdownMenu` entry to `RESPONSIVE_SIZE_MAPS` in `src/utils/responsive.ts`.
- Exported `DropdownMenu`/`DropdownMenuProps`/`DropdownMenuItem`/`DropdownMenuTriggerProps` from `src/components/index.ts`.
- Stories (`DropdownMenu.stories.tsx`): Default, AlignStart, AlignEnd, sizes (Small/Medium/Large), Disabled, WithDangerAndDisabledItems, Interactive (real uncontrolled behavior), ControlledDemo, and an AllVariants render story (cyberpunk copy throughout, e.g. "Revoke Access", "Purge Local Cache", "Neural Link").
- Tests (`DropdownMenu.test.tsx`, 20 cases): renders trigger without crashing, `aria-haspopup`/`aria-expanded`/`aria-controls` wiring, opens/closes on trigger click, closes on outside click, item `onClick` firing + close-on-select (default and `closeOnSelect={false}`), disabled item skipped on click, `danger` styling class, ArrowDown/ArrowUp opening focused on first/last item, in-menu ArrowDown/ArrowUp wraparound, disabled-item skipping during navigation, Home/End, Enter selection, Escape close + focus return to trigger, disabled dropdown never opens, controlled `open`/`onOpenChange` without self-managing state, render-prop trigger support, responsive size prop.
- Wired `DropdownMenu` into `scripts/generate-manifest.js` (`CATEGORY_MAP` → Navigation, alongside `TabNavigation`; `DOC_SUMMARIES`) and regenerated docs via `npm run docs:generate` — diff reviewed, only `DropdownMenu`-related lines changed (plus the expected `packageVersion`/`generatedAt` drift already present from the last release).
- Added a CHANGELOG entry under `[Unreleased]`.

## Test plan
- [x] npm run lint / type-check / test -- --project=unit all pass (291 tests, including 20 new for DropdownMenu)
- [ ] Storybook: Default + variants + sizes + disabled + AllVariants render correctly
- [ ] Keyboard nav + screen reader smoke test

---
_Generated by [Claude Code](https://claude.ai/code/session_011snv4EhkyznBngcvEA5x1g)_