### PR TITLE
fix: clear TabDropdown timers on unmount in TabNavigation

### DIFF
--- a/src/components/TabNavigation.test.tsx
+++ b/src/components/TabNavigation.test.tsx
@@ -33,15 +33,37 @@ describe('TabNavigation Component', () => {
 
   it('renders in dropdown mode and opens on click', async () => {
     render(<TabNavigation tabs={tabs} activeTab="NEURAL" onTabChange={vi.fn()} mode="dropdown" />);
-    
+
     // In dropdown mode, active tab label is shown on the button
     const dropdownButton = screen.getByRole('button', { expanded: false });
     expect(dropdownButton).toHaveTextContent('NEURAL');
-    
+
     fireEvent.click(dropdownButton);
     expect(dropdownButton).toHaveAttribute('aria-expanded', 'true');
-    
+
     // Tabs should now be visible in the dropdown menu
     expect(await screen.findByText('SIGNAL', { selector: 'button span' })).toBeInTheDocument();
+  });
+
+  it('does not update state after unmount from a pending tab-select close timer', () => {
+    // Regression: selecting a tab (closeOnSelect) scheduled an untracked
+    // setTimeout that fired setState even after the component unmounted.
+    vi.useFakeTimers();
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    try {
+      const { unmount } = render(
+        <TabNavigation tabs={tabs} activeTab="NEURAL" onTabChange={vi.fn()} mode="dropdown" />
+      );
+      fireEvent.click(screen.getByRole('button', { expanded: false }));
+      fireEvent.click(screen.getByText('SIGNAL', { selector: 'button span' }));
+
+      unmount();
+      vi.advanceTimersByTime(200);
+
+      expect(errorSpy).not.toHaveBeenCalled();
+    } finally {
+      errorSpy.mockRestore();
+      vi.useRealTimers();
+    }
   });
 });

--- a/src/components/TabNavigation.tsx
+++ b/src/components/TabNavigation.tsx
@@ -45,6 +45,15 @@ const TabDropdown: React.FC<TabDropdownProps> = ({
   const [alignRight, setAlignRight] = useState(false);
   const wrapperRef = useRef<HTMLDivElement | null>(null);
   const menuRef = useRef<HTMLDivElement | null>(null);
+  const closeTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const openTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    return () => {
+      if (closeTimeoutRef.current) clearTimeout(closeTimeoutRef.current);
+      if (openTimeoutRef.current) clearTimeout(openTimeoutRef.current);
+    };
+  }, []);
 
   useEffect(() => {
     if (!open) return;
@@ -55,7 +64,8 @@ const TabDropdown: React.FC<TabDropdownProps> = ({
       ) {
         // JS-staged close to align with Image component behavior
         setIsClosing(true);
-        setTimeout(() => {
+        if (closeTimeoutRef.current) clearTimeout(closeTimeoutRef.current);
+        closeTimeoutRef.current = setTimeout(() => {
           setOpen(false);
           setIsClosing(false);
         }, 180);
@@ -76,14 +86,16 @@ const TabDropdown: React.FC<TabDropdownProps> = ({
   const toggleOpen = () => {
     if (open) {
       setIsClosing(true);
-      setTimeout(() => {
+      if (closeTimeoutRef.current) clearTimeout(closeTimeoutRef.current);
+      closeTimeoutRef.current = setTimeout(() => {
         setOpen(false);
         setIsClosing(false);
       }, 180);
     } else {
       setIsOpening(true);
       setOpen(true);
-      setTimeout(() => setIsOpening(false), 30);
+      if (openTimeoutRef.current) clearTimeout(openTimeoutRef.current);
+      openTimeoutRef.current = setTimeout(() => setIsOpening(false), 30);
     }
   };
 

--- a/src/components/TabNavigation.tsx
+++ b/src/components/TabNavigation.tsx
@@ -142,7 +142,8 @@ const TabDropdown: React.FC<TabDropdownProps> = ({
                     onTabChange(tab);
                     if (closeOnSelect) {
                       setIsClosing(true);
-                      setTimeout(() => {
+                      if (closeTimeoutRef.current) clearTimeout(closeTimeoutRef.current);
+                      closeTimeoutRef.current = setTimeout(() => {
                         setOpen(false);
                         setIsClosing(false);
                       }, 180);


### PR DESCRIPTION
## Summary
- `TabDropdown` (inside `TabNavigation`) scheduled `setTimeout` calls for its open/close animation stagger (outside-click close, toggle-button open/close, and tab-select close) without ever cancelling them.
- If the component unmounted before a timer fired, the pending `setState` call could run against a torn-down environment — in CI this surfaced as an unhandled `ReferenceError: window is not defined` in `TabNavigation.test.tsx`, failing the whole "Lint, Type-check, Unit Tests" job even though all 312 tests individually passed.
- First pass tracked two of the three timers (`closeTimeoutRef`/`openTimeoutRef` for outside-click and the anchor toggle button) but missed the third: the tab-select close timer inside `closeOnSelect`. That gap meant the same class of bug — and a secondary race where selecting a tab then immediately reopening the menu within 180ms could get force-closed by the stale timer — was still reachable.

## Changes
- `src/components/TabNavigation.tsx`: added `closeTimeoutRef`/`openTimeoutRef`, clear-before-set on every timer call site (outside-click close, toggle-button open/close, and tab-select close), and a `useEffect` cleanup that clears both refs on unmount.
- `src/components/TabNavigation.test.tsx`: added a regression test that selects a tab, unmounts before the 180ms close timer fires, advances fake timers, and asserts no `console.error`/state-update-after-unmount warning occurs.

## Test plan
- [x] `npm run lint` / `type-check` / unit tests all pass
- [x] New regression test reproduces the original failure mode (fails without the fix, passes with it)

---
_Split out from #23 (`feat: add Pagination component`) since it's an unrelated fix to a different component and shouldn't block or be blocked by that review._

🤖 Generated with [Claude Code](https://claude.com/claude-code)